### PR TITLE
Fix resources

### DIFF
--- a/ppp_questionparsing_grammatical/normalization.py
+++ b/ppp_questionparsing_grammatical/normalization.py
@@ -22,14 +22,15 @@ def normalizeSuperlative(tree):
         Handle Rspl dependency (superlative, ordinal)
     """
     assert len(tree.getWords()) == 1 and len(tree.child) == 1
-    if buildValue(tree) in superlativeNoun:
-        if buildValue(tree) in superlativeOrder:
-            return superlativeOrder[buildValue(tree)](list=Sort(list=normalize(tree.child[0]),predicate=Resource(value=superlativeNoun[buildValue(tree)])))
+    superlative = buildValue(tree)
+    if superlative in superlativeNoun:
+        if superlative in superlativeOrder:
+            return superlativeOrder[superlative](list=Sort(list=normalize(tree.child[0]),predicate=Resource(value=superlativeNoun[superlative])))
         else:
-            return First(list=Sort(list=normalize(tree.child[0]),predicate=Resource(value=superlativeNoun[buildValue(tree)]))) # First by default
+            return First(list=Sort(list=normalize(tree.child[0]),predicate=Resource(value=superlativeNoun[superlative]))) # First by default
     else:
-        if buildValue(tree) in superlativeOrder:
-            return superlativeOrder[buildValue(tree)](list=Sort(list=normalize(tree.child[0]),predicate=Resource(value='default'))) # default predicate
+        if superlative in superlativeOrder:
+            return superlativeOrder[superlative](list=Sort(list=normalize(tree.child[0]),predicate=Resource(value='default'))) # default predicate
         else:
             return First(list=Sort(list=normalize(tree.child[0]),predicate=Resource(value='default')))
 
@@ -40,14 +41,15 @@ def normalizeConjunction(tree):
     result = []
     assert len(tree.getWords()) == 1
     assert len(tree.child) == 2 and tree.child[0].dependency.startswith('Rconj') and tree.child[1].dependency.startswith('Rconj')
+    conjunction = buildValue(tree)
     if tree.child[0].dependency == 'RconjT':
         result = [normalize(tree.child[0]),normalize(tree.child[1])]
     else:
         result = [normalize(tree.child[1]),normalize(tree.child[0])]    
     try:
-        return conjunctionTab[buildValue(tree)](list=result)
+        return conjunctionTab[conjunction](list=result)
     except KeyError:
-        raise GrammaticalError(buildValue(tree),"conjunction unknown")
+        raise GrammaticalError(conjunction,"conjunction unknown")
 
 def normalize(tree):
     """

--- a/tests/test_deep.py
+++ b/tests/test_deep.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from ppp_datamodel.communication import Request
-from ppp_datamodel import Triple, Resource, Missing, Intersection, Exists
+from ppp_datamodel import Triple, Resource, Missing, Intersection, Exists, List
 from ppp_libmodule.tests import PPPTestCase
 
 from ppp_questionparsing_grammatical import app
@@ -39,8 +39,8 @@ class RequestHandlerTest(PPPTestCase(app)):
         tree = answer[0].tree
         self.assertIsInstance(tree, Triple)
         predicate = tree.predicate
-        self.assertIsInstance(predicate,Resource)
-        self.assertTrue('birth date' in predicate.value)
+        self.assertIsInstance(predicate,List)
+        self.assertTrue(Resource(value='birth date') in predicate.list)
         self.assertIsInstance(tree.object, Missing)
         self.assertIsInstance(tree.subject, Triple)
         tree = tree.subject
@@ -67,10 +67,10 @@ class RequestHandlerTest(PPPTestCase(app)):
         self.assertIsInstance(l[1],Triple)
         self.assertTrue(l[0].subject == Resource('Le Petit Prince') or l[1].subject == Resource('Le Petit Prince'))
         self.assertTrue(l[0].subject == Resource('Vol de Nuit') or l[1].subject == Resource('Vol de Nuit'))
-        self.assertIsInstance(l[0].predicate, Resource)
-        self.assertIsInstance(l[1].predicate, Resource)
-        self.assertTrue('writer' in l[0].predicate.value)
-        self.assertTrue('writer' in l[1].predicate.value)
+        self.assertIsInstance(l[0].predicate, List)
+        self.assertIsInstance(l[1].predicate, List)
+        self.assertTrue(Resource(value='writer') in l[0].predicate.list)
+        self.assertTrue(Resource(value='writer') in l[1].predicate.list)
         self.assertIsInstance(l[0].object, Missing)
         self.assertIsInstance(l[1].object, Missing)
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -120,29 +120,47 @@ class StandardTripleTests(TestCase):
             "object": {
                 "type": "missing"
             },
+            "predicate": {
+                "list": [
+                    {
+                        "value": "author",
+                        "type": "resource"
+                    },
+                    {
+                        "value": "writer",
+                        "type": "resource"
+                    }
+                ],
+                "type": "list"
+            },
             "subject": {
                 "value": "Lucy in the Sky with Diamonds",
                 "type": "resource"
             },
-            "type": "triple",
-            "predicate": {
-                "value": ["author","writer"],
-                "type": "resource"
-            }
+            "type": "triple"
         },
         {
             "object": {
                 "type": "missing"
             },
+            "predicate": {
+                "list": [
+                    {
+                        "value": "author",
+                        "type": "resource"
+                    },
+                    {
+                        "value": "writer",
+                        "type": "resource"
+                    }
+                ],
+                "type": "list"
+            },
             "subject": {
                 "value": "Let It Be",
                 "type": "resource"
             },
-            "type": "triple",
-            "predicate": {
-                "value": ["author","writer"],
-                "type": "resource"
-            }
+            "type": "triple"
         }
     ],
     "type": "intersection"
@@ -191,16 +209,29 @@ class StandardTripleTests(TestCase):
         qw = simplify(tree)
         result = normalize(tree)
         self.assertEqual(result,{
-    "predicate": {
-        "value": ["place","location","residence"],
-        "type": "resource"
+    "subject": {
+        "type": "resource",
+        "value": "mistake"
     },
     "object": {
         "type": "missing"
     },
-    "subject": {
-        "value": "mistake",
-        "type": "resource"
+    "predicate": {
+        "type": "list",
+        "list": [
+            {
+                "type": "resource",
+                "value": "place"
+            },
+            {
+                "type": "resource",
+                "value": "location"
+            },
+            {
+                "type": "resource",
+                "value": "residence"
+            }
+        ]
     },
     "type": "triple"
 })


### PR DESCRIPTION
See https://github.com/ProjetPP/PPP-QuestionParsing-Grammatical/issues/99
@ProgVal @Ezibenroc Please be sure that it does what you want. For instance, in order to test lists into predicates, use `demo6.py` (see the readme) with the example `Where does the prime minister of United Kingdom live?` : 
```
{
    "subject": {
        "subject": {
            "value": "United Kingdom",
            "type": "resource"
        },
        "object": {
            "type": "missing"
        },
        "type": "triple",
        "predicate": {
            "value": "prime minister",
            "type": "resource"
        }
    },
    "object": {
        "type": "missing"
    },
    "type": "triple",
    "predicate": {
        "type": "list",
        "list": [
            {
                "value": "place",
                "type": "resource"
            },
            {
                "value": "home",
                "type": "resource"
            },
            {
                "value": "residence",
                "type": "resource"
            },
            {
                "value": "address",
                "type": "resource"
            }
        ]
    }
}
```