### PR TITLE
CoreNLP server, fix #148

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
     - sudo add-apt-repository ppa:webupd8team/java -y
     - sudo apt-get update
     - sudo apt-get install oracle-java8-installer
+    - sudo update-alternatives --set java /usr/lib/jvm/java-8-oracle/jre/bin/java
+    - sudo update-alternatives --set javac /usr/lib/jvm/java-8-oracle/bin/javac
     - pip install scrutinizer-ocular coverage webtest httmock requests ppp_datamodel ppp_core jsonrpclib-pelix nltk
     - echo "y
         y

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - sudo add-apt-repository ppa:webupd8team/java -y
     - sudo apt-get update
     - sudo apt-get install oracle-java8-installer
+    - sudo update-java-alternatives -s jdk-8-oracle-x64
     - pip install scrutinizer-ocular coverage webtest httmock requests ppp_datamodel ppp_core jsonrpclib-pelix nltk
     - echo "y
         y

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ install:
     - sudo add-apt-repository ppa:webupd8team/java -y
     - sudo apt-get update
     - sudo apt-get install oracle-java8-installer
-    - sudo update-java-alternatives -s jdk-8-oracle-x64
     - pip install scrutinizer-ocular coverage webtest httmock requests ppp_datamodel ppp_core jsonrpclib-pelix nltk
     - echo "y
         y

--- a/demo/demo2.py
+++ b/demo/demo2.py
@@ -7,7 +7,7 @@ class StanfordNLP:
         self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/demo/demo2.py
+++ b/demo/demo2.py
@@ -1,13 +1,16 @@
 import json
 #from jsonrpc import ServerProxy, JsonRpc20, TransportTcpIp
-import jsonrpclib
+import requests
 
 class StanfordNLP:
-    def __init__(self, port_number=8080):
-        self.server = jsonrpclib.Server("http://localhost:%d" % port_number)
+    def __init__(self, port_number=9000):
+        self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        return json.loads(self.server.parse(text))
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        result = r.json()['sentences'][0]
+        result['text'] = text
+        return result
 
 nlp = StanfordNLP()
 
@@ -15,4 +18,4 @@ if __name__ == "__main__":
     while(True):
         line=input("")
         result = nlp.parse(line)
-        print(result['sentences'][0]['indexeddependencies'])
+        print(result)

--- a/demo/demo3.py
+++ b/demo/demo3.py
@@ -13,7 +13,7 @@ class StanfordNLP:
         self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/demo/demo3.py
+++ b/demo/demo3.py
@@ -1,6 +1,6 @@
 import json
 #from jsonrpc import ServerProxy, JsonRpc20, TransportTcpIp
-import jsonrpclib
+import requests
 import fileinput
 import os
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -9,17 +9,20 @@ os.environ['PPP_QUESTIONPARSING_GRAMMATICAL_CONFIG'] = '../example_config.json'
 import ppp_questionparsing_grammatical
 
 class StanfordNLP:
-    def __init__(self, port_number=8080):
-        self.server = jsonrpclib.Server("http://localhost:%d" % port_number)
+    def __init__(self, port_number=9000):
+        self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        return json.loads(self.server.parse(text))
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        result = r.json()['sentences'][0]
+        result['text'] = text
+        return result
 
 def get_tree():
     nlp = StanfordNLP()
     sentence = input("")
     result = nlp.parse(sentence)
-    tree = ppp_questionparsing_grammatical.computeTree(result['sentences'][0])
+    tree = ppp_questionparsing_grammatical.computeTree(result)
     return tree
 
 if __name__ == "__main__":

--- a/demo/demo4.py
+++ b/demo/demo4.py
@@ -27,6 +27,7 @@ def get_tree():
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
+    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     return tree
 
 if __name__ == "__main__":

--- a/demo/demo4.py
+++ b/demo/demo4.py
@@ -1,6 +1,6 @@
 import json
 #from jsonrpc import ServerProxy, JsonRpc20, TransportTcpIp
-import jsonrpclib
+import requests
 import fileinput
 import os
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -9,11 +9,14 @@ os.environ['PPP_QUESTIONPARSING_GRAMMATICAL_CONFIG'] = '../example_config.json'
 import ppp_questionparsing_grammatical
 
 class StanfordNLP:
-    def __init__(self, port_number=8080):
-        self.server = jsonrpclib.Server("http://localhost:%d" % port_number)
+    def __init__(self, port_number=9000):
+        self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        return json.loads(self.server.parse(text))
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        result = r.json()['sentences'][0]
+        result['text'] = text
+        return result
 
 def get_tree():
     nlp = StanfordNLP()
@@ -21,7 +24,7 @@ def get_tree():
     handler = ppp_questionparsing_grammatical.QuotationHandler()
     simplifiedSentence = handler.pull(sentence)
     result = nlp.parse(simplifiedSentence)
-    tree = ppp_questionparsing_grammatical.computeTree(result['sentences'][0])
+    tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
     ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()

--- a/demo/demo4.py
+++ b/demo/demo4.py
@@ -13,7 +13,7 @@ class StanfordNLP:
         self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/demo/demo4.py
+++ b/demo/demo4.py
@@ -27,7 +27,6 @@ def get_tree():
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
-    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     return tree
 
 if __name__ == "__main__":

--- a/demo/demo5.py
+++ b/demo/demo5.py
@@ -1,6 +1,6 @@
 import json
 #from jsonrpc import ServerProxy, JsonRpc20, TransportTcpIp
-import jsonrpclib
+import requests
 import fileinput
 import os
 parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -9,11 +9,14 @@ os.environ['PPP_QUESTIONPARSING_GRAMMATICAL_CONFIG'] = '../example_config.json'
 import ppp_questionparsing_grammatical
 
 class StanfordNLP:
-    def __init__(self, port_number=8080):
-        self.server = jsonrpclib.Server("http://localhost:%d" % port_number)
+    def __init__(self, port_number=9000):
+        self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        return json.loads(self.server.parse(text))
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        result = r.json()['sentences'][0]
+        result['text'] = text
+        return result
 
 def get_tree():
     nlp = StanfordNLP()
@@ -21,7 +24,7 @@ def get_tree():
     handler = ppp_questionparsing_grammatical.QuotationHandler()
     simplifiedSentence = handler.pull(sentence)
     result = nlp.parse(simplifiedSentence)
-    tree = ppp_questionparsing_grammatical.computeTree(result['sentences'][0])
+    tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
     ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()

--- a/demo/demo5.py
+++ b/demo/demo5.py
@@ -27,7 +27,6 @@ def get_tree():
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
-    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     qw = ppp_questionparsing_grammatical.simplify(tree)
     return tree
 

--- a/demo/demo5.py
+++ b/demo/demo5.py
@@ -13,7 +13,7 @@ class StanfordNLP:
         self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/demo/demo5.py
+++ b/demo/demo5.py
@@ -27,6 +27,7 @@ def get_tree():
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
+    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     qw = ppp_questionparsing_grammatical.simplify(tree)
     return tree
 

--- a/demo/demo6.py
+++ b/demo/demo6.py
@@ -1,6 +1,6 @@
 import json
 #from jsonrpc import ServerProxy, JsonRpc20, TransportTcpIp
-import jsonrpclib
+import requests
 import fileinput
 import os
 import time
@@ -11,11 +11,14 @@ os.environ['PPP_QUESTIONPARSING_GRAMMATICAL_CONFIG'] = '../example_config.json'
 import ppp_questionparsing_grammatical
 
 class StanfordNLP:
-    def __init__(self, port_number=8080):
-        self.server = jsonrpclib.Server("http://localhost:%d" % port_number)
+    def __init__(self, port_number=9000):
+        self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        return json.loads(self.server.parse(text))
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        result = r.json()['sentences'][0]
+        result['text'] = text
+        return result
 
 def get_answer(sentence=""):
     nlp = StanfordNLP()
@@ -24,7 +27,7 @@ def get_answer(sentence=""):
     handler = ppp_questionparsing_grammatical.QuotationHandler()
     simplifiedSentence = handler.pull(sentence)
     result = nlp.parse(simplifiedSentence)
-    tree = ppp_questionparsing_grammatical.computeTree(result['sentences'][0])
+    tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
     ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()

--- a/demo/demo6.py
+++ b/demo/demo6.py
@@ -30,6 +30,7 @@ def get_answer(sentence=""):
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
+    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     qw = ppp_questionparsing_grammatical.simplify(tree)
     t = ppp_questionparsing_grammatical.normalFormProduction(tree,qw)
     return t

--- a/demo/demo6.py
+++ b/demo/demo6.py
@@ -15,7 +15,7 @@ class StanfordNLP:
         self.server = "http://localhost:%d" % port_number
 
     def parse(self, text):
-        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(self.server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/demo/demo6.py
+++ b/demo/demo6.py
@@ -30,7 +30,6 @@ def get_answer(sentence=""):
     tree = ppp_questionparsing_grammatical.computeTree(result)
     handler.push(tree)
     ppp_questionparsing_grammatical.NamedEntityMerging(tree).merge()
-    ppp_questionparsing_grammatical.PrepositionMerging(tree).merge()
     qw = ppp_questionparsing_grammatical.simplify(tree)
     t = ppp_questionparsing_grammatical.normalFormProduction(tree,qw)
     return t

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -7,4 +7,6 @@ if [ ! -f $JAVA_PATH ]
 then
     export JAVA_PATH=/usr/lib/jvm/java-8-oracle/bin/java
 fi
-CORENLP="stanford-corenlp-full-*" CORENLP_OPTIONS="-parse.flags \" -makeCopulaHead\"" python3 -m corenlp &
+cd CoreNLP
+export CLASSPATH="`find . -name '*.jar'`"
+java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -9,4 +9,6 @@ then
 fi
 cd CoreNLP
 export CLASSPATH="`find . -name '*.jar'`"
-java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer
+java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer &
+sleep 1 # Let the server some time to start...
+echo "CoreNLP server launched in background: PID $! "

--- a/example_config.json
+++ b/example_config.json
@@ -7,6 +7,6 @@
         "salt": "foo"
     },
     "corenlp_servers": [
-        "http://localhost:8080"
+        "http://localhost:9000"
     ]
 }

--- a/ppp_questionparsing_grammatical/data/nounificationManual.txt
+++ b/ppp_questionparsing_grammatical/data/nounificationManual.txt
@@ -11,6 +11,7 @@ bear in -> birthplace, place of birth, birth place
 bear on -> birth date, birthday, birthdate
 bear on <- birth
 belong to -> owner, part of
+belong -> owner, part of
 build -> construction
 build <- architecht, builder, constructor
 bury in -> location of burial, burial place

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -51,7 +51,7 @@ dependenciesMap1 = {
     'undef'     : 'R0',
     'ROOT'      : 'R0',
     'inst_of'   : 'RinstOf', # <<
-    'nmod'      : prepRule, # new dependency type, to discuss... I would have said rule 'R5', but it does not seem to be implemented
+    'nmod'      : 'RinstOf', # new dependency type, to discuss...
     'dep'       : 'R1',
         'aux'       : remove,
             'auxpass'   : remove,
@@ -109,8 +109,7 @@ dependenciesMap1 = {
         'goeswith'  : merge,
         'discourse' : remove,
         'compound'  : merge, # new dependency type, to discuss...
-        'punct'     : remove,
-        'case'      : remove,
+        'punct'     : remove
 }
 
 def propagateType(t, qw):

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -51,7 +51,7 @@ dependenciesMap1 = {
     'undef'     : 'R0',
     'ROOT'      : 'R0',
     'inst_of'   : 'RinstOf', # <<
-    'nmod'      : 'RinstOf', # new dependency type, to discuss...
+    'nmod'      : prepRule, # new dependency type, to discuss... I would have said rule 'R5', but it does not seem to be implemented
     'dep'       : 'R1',
         'aux'       : remove,
             'auxpass'   : remove,
@@ -109,7 +109,8 @@ dependenciesMap1 = {
         'goeswith'  : merge,
         'discourse' : remove,
         'compound'  : merge, # new dependency type, to discuss...
-        'punct'     : remove
+        'punct'     : remove,
+        'case'      : remove,
 }
 
 def propagateType(t, qw):

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -108,7 +108,8 @@ dependenciesMap1 = {
             'xsubj'     : 'R3',
         'goeswith'  : merge,
         'discourse' : remove,
-        'compound' : merge # new dependency type, to discuss...
+        'compound'  : merge, # new dependency type, to discuss...
+        'punct'     : remove
 }
 
 def propagateType(t, qw):

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -49,8 +49,9 @@ def prepRule(t, qw):
 
 dependenciesMap1 = {
     'undef'     : 'R0',
-    'root'      : 'R0',
+    'ROOT'      : 'R0',
     'inst_of'   : 'RinstOf', # <<
+    'nmod'      : 'RinstOf', # new dependency type, to discuss...
     'dep'       : 'R1',
         'aux'       : remove,
             'auxpass'   : remove,
@@ -106,7 +107,8 @@ dependenciesMap1 = {
         'sdep'      : impossible,
             'xsubj'     : 'R3',
         'goeswith'  : merge,
-        'discourse' : remove
+        'discourse' : remove,
+        'compound' : merge # new dependency type, to discuss...
 }
 
 def propagateType(t, qw):

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -51,7 +51,7 @@ dependenciesMap1 = {
     'undef'     : 'R0',
     'ROOT'      : 'R0',
     'inst_of'   : 'RinstOf', # <<
-    'nmod'      : 'RinstOf', # new dependency type, to discuss...
+    'nmod'      : impossible, # new dependency type, to discuss...
     'dep'       : 'R1',
         'aux'       : remove,
             'auxpass'   : remove,
@@ -96,6 +96,7 @@ dependenciesMap1 = {
             'npadvmod'  : 'R2',
                 'tmod'      : 'R3',
             'num'       : merge,
+            'nummod'    : merge,
             'number'    : merge,
             'prep'      : prepRule, # <<
             'poss'      : 'R2',

--- a/ppp_questionparsing_grammatical/dependencyAnalysis.py
+++ b/ppp_questionparsing_grammatical/dependencyAnalysis.py
@@ -110,7 +110,6 @@ dependenciesMap1 = {
         'goeswith'  : merge,
         'discourse' : remove,
         'compound'  : merge, # new dependency type, to discuss...
-        'punct'     : remove
 }
 
 def propagateType(t, qw):

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -301,6 +301,22 @@ def processPrepositions(tree):
             tree.dependency = prepositionMaping[child.getWords()]
         tree.child.remove(child)
 
+def processPunctuation(tree):
+    """
+        Remove the nodes with a 'punct' dependency.
+        This function is a temporary fix for compatibility with the new version
+        of CoreNLP (from December 2015).
+    """
+    for child in tree.child:
+        processPunctuation(child)
+    if tree.dependency == 'punct':
+        tree.parent.child.remove(tree)
+
+def processForCompatibility(tree):
+    processConjonctions(tree)
+    processPrepositions(tree)
+    processPunctuation(tree)
+
 ###################
 # Global function #
 ###################
@@ -315,6 +331,5 @@ def computeTree(stanfordResult):
     generator = TreeGenerator(stanfordResult)
     tree = generator.computeTree()
     tree.initText(stanfordResult['text'].replace('"', '\\"')) # each node contains the input question
-    processConjonctions(tree)
-    processPrepositions(tree)
+    processForCompatibility(tree)
     return tree

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -299,7 +299,6 @@ def processPrepositions(tree):
             if child.dependency == 'case':
                 break
         if ':' in tree.dependency: # example : 'nmod:poss'
-            assert child.getWords() == '' # any counter example?
             tree.dependency = tree.dependency[tree.dependency.index(':')+1:]
         else:
             tree.dependency = prepositionMaping[child.getWords().lower()]

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -301,7 +301,7 @@ def processPrepositions(tree):
             assert child.getWords() == '' # any counter example?
             tree.dependency = tree.dependency[tree.dependency.index(':')+1:]
         else:
-            tree.dependency = prepositionMaping[child.getWords()]
+            tree.dependency = prepositionMaping[child.getWords().lower()]
         tree.child.remove(child)
 
 def processPunctuation(tree):

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -286,13 +286,14 @@ def processPrepositions(tree):
         'by' : 'agent',
         'for' : 'prep_for',
         'in'  : 'prep_in',
-        'on'  : 'prep_on'
+        'on'  : 'prep_on',
+        'from' : 'prep_from',
     }
     for child in tree.child:
         processPrepositions(child)
     if tree.dependency.startswith('nmod'):
         if len(tree.child) == 0:
-            tree.parent.child.remove(tree)
+            tree.parent.merge(tree, True)
             return
         for child in tree.child:
             if child.dependency == 'case':

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -291,6 +291,9 @@ def processPrepositions(tree):
     for child in tree.child:
         processPrepositions(child)
     if tree.dependency.startswith('nmod'):
+        if len(tree.child) == 0:
+            tree.parent.child.remove(tree)
+            return
         for child in tree.child:
             if child.dependency == 'case':
                 break

--- a/ppp_questionparsing_grammatical/dependencyTree.py
+++ b/ppp_questionparsing_grammatical/dependencyTree.py
@@ -283,7 +283,7 @@ def processPrepositions(tree):
     """
     prepositionMaping = {
         'of' : 'prep_of',
-        'by' : 'agent',
+        'by' : 'prep_by',
         'for' : 'prep_for',
         'in'  : 'prep_in',
         'on'  : 'prep_on',

--- a/ppp_questionparsing_grammatical/questionWordProcessing.py
+++ b/ppp_questionparsing_grammatical/questionWordProcessing.py
@@ -11,7 +11,7 @@ def prepareInstanceOf(t):
     """
         Replace by 'inst_of' the highest dependency that appears on a path from the root of t to the root of the whole tree
     """
-    if t.parent and t.parent.dependency == 'root':
+    if t.parent and t.parent.dependency.lower() == 'root':
         t.dependency = 'inst_of'
         return
     elif t.parent:

--- a/ppp_questionparsing_grammatical/requesthandler.py
+++ b/ppp_questionparsing_grammatical/requesthandler.py
@@ -71,7 +71,6 @@ def parse(sentence):
     tree = computeTree(result)
     handler.push(tree)
     NamedEntityMerging(tree).merge()
-    PrepositionMerging(tree).merge()
     qw = simplify(tree)
     return normalFormProduction(tree, qw)
 

--- a/ppp_questionparsing_grammatical/requesthandler.py
+++ b/ppp_questionparsing_grammatical/requesthandler.py
@@ -71,6 +71,7 @@ def parse(sentence):
     tree = computeTree(result)
     handler.push(tree)
     NamedEntityMerging(tree).merge()
+    PrepositionMerging(tree).merge()
     qw = simplify(tree)
     return normalFormProduction(tree, qw)
 

--- a/ppp_questionparsing_grammatical/requesthandler.py
+++ b/ppp_questionparsing_grammatical/requesthandler.py
@@ -35,8 +35,12 @@ class StanfordNLP:
         self.servers = urls
 
     def _parse(self, text):
+        '''
+            Need to run CoreNLP server with version > 3.6.0.
+            See http://stackoverflow.com/questions/36206407/utf-8-issue-with-corenlp-server
+        '''
         server = random.choice(self.servers)
-        r = requests.post(server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text)
+        r = requests.post(server, params={'properties' : '{"annotators": "tokenize,ssplit,pos,lemma,ner,parse", "outputFormat": "json", "parse.flags": " -makeCopulaHead"}'}, data=text.encode('utf8'))
         result = r.json()['sentences'][0]
         result['text'] = text
         return result

--- a/tests/data.py
+++ b/tests/data.py
@@ -2,83 +2,22 @@ from ppp_questionparsing_grammatical import computeTree, simplify, DependenciesT
 
 # Parsing result of "John Smith lives in the United Kingdom."
 def give_john_smith():
-    return  {'sentences': [{'dependencies': [['root', 'ROOT', 'lives'],
-                ['nn', 'Smith', 'John'],
-                ['nsubj', 'lives', 'Smith'],
-                ['det', 'Kingdom', 'the'],
-                ['nn', 'Kingdom', 'United'],
-                ['prep_in', 'lives', 'Kingdom']],
-               'indexeddependencies': [['root', 'ROOT-0', 'lives-3'],
-                ['nn', 'Smith-2', 'John-1'],
-                ['nsubj', 'lives-3', 'Smith-2'],
-                ['det', 'Kingdom-7', 'the-5'],
-                ['nn', 'Kingdom-7', 'United-6'],
-                ['prep_in', 'lives-3', 'Kingdom-7']],
-               'parsetree': '(ROOT (S (NP (NNP John) (NNP Smith)) (VP (VBZ lives) (PP (IN in) (NP (DT the) (NNP United) (NNP Kingdom)))) (. .)))',
-               'text': 'John Smith lives in the United Kingdom.',
-               'words': [['John',
-                 {'CharacterOffsetBegin': '0',
-                  'CharacterOffsetEnd': '4',
-                  'Lemma': 'John',
-                  'NamedEntityTag': 'PERSON',
-                  'PartOfSpeech': 'NNP'}],
-                ['Smith',
-                 {'CharacterOffsetBegin': '5',
-                  'CharacterOffsetEnd': '10',
-                  'Lemma': 'Smith',
-                  'NamedEntityTag': 'PERSON',
-                  'PartOfSpeech': 'NNP'}],
-                ['lives',
-                 {'CharacterOffsetBegin': '11',
-                  'CharacterOffsetEnd': '16',
-                  'Lemma': 'live',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'VBZ'}],
-                ['in',
-                 {'CharacterOffsetBegin': '17',
-                  'CharacterOffsetEnd': '19',
-                  'Lemma': 'in',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'IN'}],
-                ['the',
-                 {'CharacterOffsetBegin': '20',
-                  'CharacterOffsetEnd': '23',
-                  'Lemma': 'the',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'DT'}],
-                ['United',
-                 {'CharacterOffsetBegin': '24',
-                  'CharacterOffsetEnd': '30',
-                  'Lemma': 'United',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNP'}],
-                ['Kingdom',
-                 {'CharacterOffsetBegin': '31',
-                  'CharacterOffsetEnd': '38',
-                  'Lemma': 'Kingdom',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNP'}],
-                ['.',
-                 {'CharacterOffsetBegin': '38',
-                  'CharacterOffsetEnd': '39',
-                  'Lemma': '.',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': '.'}]]}]}
+    return {'collapsed-dependencies': [{'dependent': 3, 'governor': 0, 'governorGloss': 'ROOT', 'dependentGloss': 'lives', 'dep': 'ROOT'}, {'dependent': 1, 'governor': 2, 'governorGloss': 'Smith', 'dependentGloss': 'John', 'dep': 'compound'}, {'dependent': 2, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Smith', 'dep': 'nsubj'}, {'dependent': 4, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'in', 'dep': 'case'}, {'dependent': 5, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'the', 'dep': 'det'}, {'dependent': 6, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'United', 'dep': 'compound'}, {'dependent': 7, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Kingdom', 'dep': 'nmod:in'}, {'dependent': 8, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': '.', 'dep': 'punct'}], 'basic-dependencies': [{'dependent': 3, 'governor': 0, 'governorGloss': 'ROOT', 'dependentGloss': 'lives', 'dep': 'ROOT'}, {'dependent': 1, 'governor': 2, 'governorGloss': 'Smith', 'dependentGloss': 'John', 'dep': 'compound'}, {'dependent': 2, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Smith', 'dep': 'nsubj'}, {'dependent': 4, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'in', 'dep': 'case'}, {'dependent': 5, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'the', 'dep': 'det'}, {'dependent': 6, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'United', 'dep': 'compound'}, {'dependent': 7, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Kingdom', 'dep': 'nmod'}, {'dependent': 8, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': '.', 'dep': 'punct'}], 'collapsed-ccprocessed-dependencies': [{'dependent': 3, 'governor': 0, 'governorGloss': 'ROOT', 'dependentGloss': 'lives', 'dep': 'ROOT'}, {'dependent': 1, 'governor': 2, 'governorGloss': 'Smith', 'dependentGloss': 'John', 'dep': 'compound'}, {'dependent': 2, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Smith', 'dep': 'nsubj'}, {'dependent': 4, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'in', 'dep': 'case'}, {'dependent': 5, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'the', 'dep': 'det'}, {'dependent': 6, 'governor': 7, 'governorGloss': 'Kingdom', 'dependentGloss': 'United', 'dep': 'compound'}, {'dependent': 7, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': 'Kingdom', 'dep': 'nmod:in'}, {'dependent': 8, 'governor': 3, 'governorGloss': 'lives', 'dependentGloss': '.', 'dep': 'punct'}], 'parse': '(ROOT\n  (S\n    (NP (NNP John) (NNP Smith))\n    (VP (VBZ lives)\n      (PP (IN in)\n        (NP (DT the) (NNP United) (NNP Kingdom))))\n    (. .)))', 'index': 0, 'text': 'John Smith lives in the United Kingdom.', 'tokens': [{'after': ' ', 'ner': 'PERSON', 'characterOffsetBegin': 0, 'lemma': 'John', 'word': 'John', 'before': '', 'characterOffsetEnd': 4, 'originalText': 'John', 'index': 1, 'pos': 'NNP'}, {'after': ' ', 'ner': 'PERSON', 'characterOffsetBegin': 5, 'lemma': 'Smith', 'word': 'Smith', 'before': ' ', 'characterOffsetEnd': 10, 'originalText': 'Smith', 'index': 2, 'pos': 'NNP'}, {'after': ' ', 'ner': 'O', 'characterOffsetBegin': 11, 'lemma': 'live', 'word': 'lives', 'before': ' ', 'characterOffsetEnd': 16, 'originalText': 'lives', 'index': 3, 'pos': 'VBZ'}, {'after': ' ', 'ner': 'O', 'characterOffsetBegin': 17, 'lemma': 'in', 'word': 'in', 'before': ' ', 'characterOffsetEnd': 19, 'originalText': 'in', 'index': 4, 'pos': 'IN'}, {'after': ' ', 'ner': 'O', 'characterOffsetBegin': 20, 'lemma': 'the', 'word': 'the', 'before': ' ', 'characterOffsetEnd': 23, 'originalText': 'the', 'index': 5, 'pos': 'DT'}, {'after': ' ', 'ner': 'LOCATION', 'characterOffsetBegin': 24, 'lemma': 'United', 'word': 'United', 'before': ' ', 'characterOffsetEnd': 30, 'originalText': 'United', 'index': 6, 'pos': 'NNP'}, {'after': '', 'ner': 'LOCATION', 'characterOffsetBegin': 31, 'lemma': 'Kingdom', 'word': 'Kingdom', 'before': ' ', 'characterOffsetEnd': 38, 'originalText': 'Kingdom', 'index': 7, 'pos': 'NNP'}, {'after': '', 'ner': 'O', 'characterOffsetBegin': 38, 'lemma': '.', 'word': '.', 'before': '', 'characterOffsetEnd': 39, 'originalText': '.', 'index': 8, 'pos': '.'}]}
 
 # Dot representation of the tree for "John Smith lives in the United Kingdom."
 def give_john_smith_string():
     s="digraph relations {\n"
     s+="\t\"6\"[label=\"ROOT\", shape=box];\n"
-    s+="\t\"6\" -> \"5\"[label=\"root\"];\n"
+    s+="\t\"6\" -> \"5\"[label=\"ROOT\"];\n"
     s+="\t\"5\"[label=\"lives\", shape=box];\n"
     s+="\t\"5\" -> \"1\"[label=\"nsubj\"];\n"
     s+="\t\"5\" -> \"4\"[label=\"prep_in\"];\n"
     s+="\t\"1\"[label=\"Smith [PERSON]\", shape=box];\n"
-    s+="\t\"1\" -> \"0\"[label=\"nn\"];\n"
+    s+="\t\"1\" -> \"0\"[label=\"compound\"];\n"
     s+="\t\"0\"[label=\"John [PERSON]\", shape=box];\n"
     s+="\t\"4\"[label=\"Kingdom [LOCATION]\", shape=box];\n"
     s+="\t\"4\" -> \"2\"[label=\"det\"];\n"
-    s+="\t\"4\" -> \"3\"[label=\"nn\"];\n"
+    s+="\t\"4\" -> \"3\"[label=\"compound\"];\n"
     s+="\t\"2\"[label=\"the\", shape=box];\n"
     s+="\t\"3\"[label=\"United [LOCATION]\", shape=box];\n"
     s+="\tlabelloc=\"t\"\tlabel=\"John Smith lives in the United Kingdom.\";\n"
@@ -89,7 +28,7 @@ def give_john_smith_string():
 def give_john_smith_stringMerge():
     s="digraph relations {\n"
     s+="\t\"4\"[label=\"ROOT\", shape=box];\n"
-    s+="\t\"4\" -> \"3\"[label=\"root\"];\n"
+    s+="\t\"4\" -> \"3\"[label=\"ROOT\"];\n"
     s+="\t\"3\"[label=\"lives in\", shape=box];\n"
     s+="\t\"3\" -> \"0\"[label=\"nsubj\"];\n"
     s+="\t\"3\" -> \"2\"[label=\"prep\"];\n"
@@ -103,452 +42,83 @@ def give_john_smith_stringMerge():
 
 # Parse result of "Who wrote foo10 and foo46?"
 def give_LSD_LIB():
-    return  {'sentences': [{'dependencies': [['root', 'ROOT', 'wrote'],
-                ['nsubj', 'wrote', 'Who'],
-                ['dobj', 'wrote', 'foo10'],
-                ['conj_and', 'foo10', 'foo46']],
-               'indexeddependencies': [['root', 'ROOT-0', 'wrote-2'],
-                ['nsubj', 'wrote-2', 'Who-1'],
-                ['dobj', 'wrote-2', 'foo10-3'],
-                ['conj_and', 'foo10-3', 'foo46-5']],
-               'parsetree': '(ROOT (SBARQ (WHNP (WP Who)) (SQ (VP (VBD wrote) (NP (NN foo10) (CC and) (NN foo46)))) (. ?)))',
-               'text': 'Who wrote foo10 and foo46?',
-               'words': [['Who',
-                 {'CharacterOffsetBegin': '0',
-                  'CharacterOffsetEnd': '3',
-                  'Lemma': 'who',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'WP'}],
-                ['wrote',
-                 {'CharacterOffsetBegin': '4',
-                  'CharacterOffsetEnd': '9',
-                  'Lemma': 'write',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'VBD'}],
-                ['foo10',
-                 {'CharacterOffsetBegin': '10',
-                  'CharacterOffsetEnd': '14',
-                  'Lemma': 'foo10',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'NN'}],
-                ['and',
-                 {'CharacterOffsetBegin': '15',
-                  'CharacterOffsetEnd': '18',
-                  'Lemma': 'and',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'CC'}],
-                ['foo46',
-                 {'CharacterOffsetBegin': '19',
-                  'CharacterOffsetEnd': '23',
-                  'Lemma': 'foo46',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'NN'}],
-                ['?',
-                 {'CharacterOffsetBegin': '23',
-                  'CharacterOffsetEnd': '24',
-                  'Lemma': '?',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': '.'}]]}]}
+    return {'tokens': [{'pos': 'WP', 'characterOffsetEnd': 3, 'lemma': 'who', 'word': 'Who', 'characterOffsetBegin': 0, 'after': ' ', 'originalText': 'Who', 'ner': 'O', 'before': '', 'index': 1}, {'pos': 'VBD', 'characterOffsetEnd': 9, 'lemma': 'write', 'word': 'wrote', 'characterOffsetBegin': 4, 'after': ' ', 'originalText': 'wrote', 'ner': 'O', 'before': ' ', 'index': 2}, {'pos': 'NN', 'characterOffsetEnd': 15, 'lemma': 'foo10', 'word': 'foo10', 'characterOffsetBegin': 10, 'after': ' ', 'originalText': 'foo10', 'ner': 'O', 'before': ' ', 'index': 3}, {'pos': 'CC', 'characterOffsetEnd': 19, 'lemma': 'and', 'word': 'and', 'characterOffsetBegin': 16, 'after': ' ', 'originalText': 'and', 'ner': 'O', 'before': ' ', 'index': 4}, {'pos': 'NN', 'characterOffsetEnd': 25, 'lemma': 'foo46', 'word': 'foo46', 'characterOffsetBegin': 20, 'after': '', 'originalText': 'foo46', 'ner': 'O', 'before': ' ', 'index': 5}, {'pos': '.', 'characterOffsetEnd': 26, 'lemma': '?', 'word': '?', 'characterOffsetBegin': 25, 'after': '', 'originalText': '?', 'ner': 'O', 'before': '', 'index': 6}], 'basic-dependencies': [{'dependentGloss': 'wrote', 'dep': 'ROOT', 'governor': 0, 'dependent': 2, 'governorGloss': 'ROOT'}, {'dependentGloss': 'Who', 'dep': 'nsubj', 'governor': 2, 'dependent': 1, 'governorGloss': 'wrote'}, {'dependentGloss': 'foo10', 'dep': 'dobj', 'governor': 2, 'dependent': 3, 'governorGloss': 'wrote'}, {'dependentGloss': 'and', 'dep': 'cc', 'governor': 3, 'dependent': 4, 'governorGloss': 'foo10'}, {'dependentGloss': 'foo46', 'dep': 'conj', 'governor': 3, 'dependent': 5, 'governorGloss': 'foo10'}, {'dependentGloss': '?', 'dep': 'punct', 'governor': 2, 'dependent': 6, 'governorGloss': 'wrote'}], 'collapsed-ccprocessed-dependencies': [{'dependentGloss': 'wrote', 'dep': 'ROOT', 'governor': 0, 'dependent': 2, 'governorGloss': 'ROOT'}, {'dependentGloss': 'Who', 'dep': 'nsubj', 'governor': 2, 'dependent': 1, 'governorGloss': 'wrote'}, {'dependentGloss': 'foo10', 'dep': 'dobj', 'governor': 2, 'dependent': 3, 'governorGloss': 'wrote'}, {'dependentGloss': 'and', 'dep': 'cc', 'governor': 3, 'dependent': 4, 'governorGloss': 'foo10'}, {'dependentGloss': 'foo46', 'dep': 'dobj', 'governor': 2, 'dependent': 5, 'governorGloss': 'wrote'}, {'dependentGloss': 'foo46', 'dep': 'conj:and', 'governor': 3, 'dependent': 5, 'governorGloss': 'foo10'}, {'dependentGloss': '?', 'dep': 'punct', 'governor': 2, 'dependent': 6, 'governorGloss': 'wrote'}], 'text': 'Who wrote foo10 and foo46?', 'collapsed-dependencies': [{'dependentGloss': 'wrote', 'dep': 'ROOT', 'governor': 0, 'dependent': 2, 'governorGloss': 'ROOT'}, {'dependentGloss': 'Who', 'dep': 'nsubj', 'governor': 2, 'dependent': 1, 'governorGloss': 'wrote'}, {'dependentGloss': 'foo10', 'dep': 'dobj', 'governor': 2, 'dependent': 3, 'governorGloss': 'wrote'}, {'dependentGloss': 'and', 'dep': 'cc', 'governor': 3, 'dependent': 4, 'governorGloss': 'foo10'}, {'dependentGloss': 'foo46', 'dep': 'conj:and', 'governor': 3, 'dependent': 5, 'governorGloss': 'foo10'}, {'dependentGloss': '?', 'dep': 'punct', 'governor': 2, 'dependent': 6, 'governorGloss': 'wrote'}], 'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP Who))\n    (SQ\n      (VP (VBD wrote)\n        (NP (NN foo10)\n          (CC and)\n          (NN foo46))))\n    (. ?)))', 'index': 0}
 
 # Parse result of "Obama is the United States president."
 def give_obama_president_usa():
-    return  {'coref': [[[['the United States president', 0, 5, 2, 6],
-                ['Obama', 0, 0, 0, 1]]]],
-             'sentences': [{'dependencies': [['root', 'ROOT', 'is'],
-                ['nsubj', 'is', 'Obama'],
-                ['det', 'president', 'the'],
-                ['nn', 'president', 'United'],
-                ['nn', 'president', 'States'],
-                ['xcomp', 'is', 'president']],
-               'indexeddependencies': [['root', 'ROOT-0', 'is-2'],
-                ['nsubj', 'is-2', 'Obama-1'],
-                ['det', 'president-6', 'the-3'],
-                ['nn', 'president-6', 'United-4'],
-                ['nn', 'president-6', 'States-5'],
-                ['xcomp', 'is-2', 'president-6']],
-               'parsetree': '(ROOT (S (NP (NNP Obama)) (VP (VBZ is) (NP (DT the) (NNP United) (NNPS States) (NN president))) (. .)))',
-               'text': 'Obama is the United States president.',
-               'words': [['Obama',
-                 {'CharacterOffsetBegin': '0',
-                  'CharacterOffsetEnd': '5',
-                  'Lemma': 'Obama',
-                  'NamedEntityTag': 'PERSON',
-                  'PartOfSpeech': 'NNP'}],
-                ['is',
-                 {'CharacterOffsetBegin': '6',
-                  'CharacterOffsetEnd': '8',
-                  'Lemma': 'be',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'VBZ'}],
-                ['the',
-                 {'CharacterOffsetBegin': '9',
-                  'CharacterOffsetEnd': '12',
-                  'Lemma': 'the',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'DT'}],
-                ['United',
-                 {'CharacterOffsetBegin': '13',
-                  'CharacterOffsetEnd': '19',
-                  'Lemma': 'United',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNP'}],
-                ['States',
-                 {'CharacterOffsetBegin': '20',
-                  'CharacterOffsetEnd': '26',
-                  'Lemma': 'States',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNPS'}],
-                ['president',
-                 {'CharacterOffsetBegin': '27',
-                  'CharacterOffsetEnd': '36',
-                  'Lemma': 'president',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'NN'}],
-                ['.',
-                 {'CharacterOffsetBegin': '36',
-                  'CharacterOffsetEnd': '37',
-                  'Lemma': '.',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': '.'}]]}]}
+    return {'parse': '(ROOT\n  (S\n    (NP (NNP Obama))\n    (VP (VBZ is)\n      (NP (DT the) (NNP United) (NNPS States) (NN president)))\n    (. .)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'Obama', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'xcomp', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '.', 'dependent': 7}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'Obama', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'xcomp', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '.', 'dependent': 7}], 'tokens': [{'originalText': 'Obama', 'characterOffsetEnd': 5, 'pos': 'NNP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'Obama', 'word': 'Obama', 'ner': 'PERSON'}, {'originalText': 'is', 'characterOffsetEnd': 8, 'pos': 'VBZ', 'characterOffsetBegin': 6, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 12, 'pos': 'DT', 'characterOffsetBegin': 9, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'United', 'characterOffsetEnd': 19, 'pos': 'NNP', 'characterOffsetBegin': 13, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'United', 'word': 'United', 'ner': 'LOCATION'}, {'originalText': 'States', 'characterOffsetEnd': 26, 'pos': 'NNPS', 'characterOffsetBegin': 20, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'States', 'word': 'States', 'ner': 'LOCATION'}, {'originalText': 'president', 'characterOffsetEnd': 36, 'pos': 'NN', 'characterOffsetBegin': 27, 'index': 6, 'after': '', 'before': ' ', 'lemma': 'president', 'word': 'president', 'ner': 'O'}, {'originalText': '.', 'characterOffsetEnd': 37, 'pos': '.', 'characterOffsetBegin': 36, 'index': 7, 'after': '', 'before': '', 'lemma': '.', 'word': '.', 'ner': 'O'}], 'text': 'Obama is the United States president.', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'Obama', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'xcomp', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '.', 'dependent': 7}]}
 
 # Parsing result of "How old are there?"
 def give_how_old():
-    return  {'sentences': [{'dependencies': [['root', 'ROOT', 'are'],
-                ['advmod', 'old', 'How'],
-                ['dep', 'are', 'old'],
-                ['expl', 'are', 'there']],
-               'indexeddependencies': [['root', 'ROOT-0', 'are-3'],
-                ['advmod', 'old-2', 'How-1'],
-                ['dep', 'are-3', 'old-2'],
-                ['expl', 'are-3', 'there-4']],
-               'parsetree': '(ROOT (SBARQ (WHADJP (WRB How) (JJ old)) (SQ (VBP are) (NP (EX there))) (. ?)))',
-               'text': 'How old are there?',
-               'words': [['How',
-                 {'CharacterOffsetBegin': '0',
-                  'CharacterOffsetEnd': '3',
-                  'Lemma': 'how',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'WRB'}],
-                ['old',
-                 {'CharacterOffsetBegin': '4',
-                  'CharacterOffsetEnd': '7',
-                  'Lemma': 'old',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'JJ'}],
-                ['are',
-                 {'CharacterOffsetBegin': '8',
-                  'CharacterOffsetEnd': '11',
-                  'Lemma': 'be',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'VBP'}],
-                ['there',
-                 {'CharacterOffsetBegin': '12',
-                  'CharacterOffsetEnd': '17',
-                  'Lemma': 'there',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'EX'}],
-                ['?',
-                 {'CharacterOffsetBegin': '17',
-                  'CharacterOffsetEnd': '18',
-                  'Lemma': '?',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': '.'}]]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHADJP (WRB How) (JJ old))\n    (SQ (VBP are)\n      (NP (EX there)))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'are', 'dependent': 3}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'old', 'dependentGloss': 'How', 'dependent': 1}, {'governor': 3, 'dep': 'dep', 'governorGloss': 'are', 'dependentGloss': 'old', 'dependent': 2}, {'governor': 3, 'dep': 'expl', 'governorGloss': 'are', 'dependentGloss': 'there', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'are', 'dependentGloss': '?', 'dependent': 5}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'are', 'dependent': 3}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'old', 'dependentGloss': 'How', 'dependent': 1}, {'governor': 3, 'dep': 'dep', 'governorGloss': 'are', 'dependentGloss': 'old', 'dependent': 2}, {'governor': 3, 'dep': 'expl', 'governorGloss': 'are', 'dependentGloss': 'there', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'are', 'dependentGloss': '?', 'dependent': 5}], 'tokens': [{'originalText': 'How', 'characterOffsetEnd': 3, 'pos': 'WRB', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'how', 'word': 'How', 'ner': 'O'}, {'originalText': 'old', 'characterOffsetEnd': 7, 'pos': 'JJ', 'characterOffsetBegin': 4, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'old', 'word': 'old', 'ner': 'O'}, {'originalText': 'are', 'characterOffsetEnd': 11, 'pos': 'VBP', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'are', 'ner': 'O'}, {'originalText': 'there', 'characterOffsetEnd': 17, 'pos': 'EX', 'characterOffsetBegin': 12, 'index': 4, 'after': '', 'before': ' ', 'lemma': 'there', 'word': 'there', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 18, 'pos': '.', 'characterOffsetBegin': 17, 'index': 5, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'How old are there?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'are', 'dependent': 3}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'old', 'dependentGloss': 'How', 'dependent': 1}, {'governor': 3, 'dep': 'dep', 'governorGloss': 'are', 'dependentGloss': 'old', 'dependent': 2}, {'governor': 3, 'dep': 'expl', 'governorGloss': 'are', 'dependentGloss': 'there', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'are', 'dependentGloss': '?', 'dependent': 5}]}
 
 # Parsing result of "Who is the United States president?"
 def give_USA_president():
-    return  {'sentences': [{'dependencies': [['root', 'ROOT', 'is'],
-                ['dep', 'is', 'Who'],
-                ['det', 'president', 'the'],
-                ['nn', 'president', 'United'],
-                ['nn', 'president', 'States'],
-                ['nsubj', 'is', 'president']],
-               'indexeddependencies': [['root', 'ROOT-0', 'is-2'],
-                ['dep', 'is-2', 'Who-1'],
-                ['det', 'president-6', 'the-3'],
-                ['nn', 'president-6', 'United-4'],
-                ['nn', 'president-6', 'States-5'],
-                ['nsubj', 'is-2', 'president-6']],
-               'parsetree': '(ROOT (SBARQ (WHNP (WP Who)) (SQ (VBZ is) (NP (DT the) (NNP United) (NNPS States) (NN president))) (. ?)))',
-               'text': 'Who is the United States president?',
-               'words': [['Who',
-                 {'CharacterOffsetBegin': '0',
-                  'CharacterOffsetEnd': '3',
-                  'Lemma': 'who',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'WP'}],
-                ['is',
-                 {'CharacterOffsetBegin': '4',
-                  'CharacterOffsetEnd': '6',
-                  'Lemma': 'be',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'VBZ'}],
-                ['the',
-                 {'CharacterOffsetBegin': '7',
-                  'CharacterOffsetEnd': '10',
-                  'Lemma': 'the',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'DT'}],
-                ['United',
-                 {'CharacterOffsetBegin': '11',
-                  'CharacterOffsetEnd': '17',
-                  'Lemma': 'United',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNP'}],
-                ['States',
-                 {'CharacterOffsetBegin': '18',
-                  'CharacterOffsetEnd': '24',
-                  'Lemma': 'States',
-                  'NamedEntityTag': 'LOCATION',
-                  'PartOfSpeech': 'NNPS'}],
-                ['president',
-                 {'CharacterOffsetBegin': '25',
-                  'CharacterOffsetEnd': '34',
-                  'Lemma': 'president',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': 'NN'}],
-                ['?',
-                 {'CharacterOffsetBegin': '34',
-                  'CharacterOffsetEnd': '35',
-                  'Lemma': '?',
-                  'NamedEntityTag': 'O',
-                  'PartOfSpeech': '.'}]]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP Who))\n    (SQ (VBZ is)\n      (NP (DT the) (NNP United) (NNPS States) (NN president)))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}], 'tokens': [{'originalText': 'Who', 'characterOffsetEnd': 3, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'who', 'word': 'Who', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 6, 'pos': 'VBZ', 'characterOffsetBegin': 4, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 10, 'pos': 'DT', 'characterOffsetBegin': 7, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'United', 'characterOffsetEnd': 17, 'pos': 'NNP', 'characterOffsetBegin': 11, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'United', 'word': 'United', 'ner': 'LOCATION'}, {'originalText': 'States', 'characterOffsetEnd': 24, 'pos': 'NNPS', 'characterOffsetBegin': 18, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'States', 'word': 'States', 'ner': 'LOCATION'}, {'originalText': 'president', 'characterOffsetEnd': 34, 'pos': 'NN', 'characterOffsetBegin': 25, 'index': 6, 'after': '', 'before': ' ', 'lemma': 'president', 'word': 'president', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 35, 'pos': '.', 'characterOffsetBegin': 34, 'index': 7, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'Who is the United States president?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'United', 'dependent': 4}, {'governor': 6, 'dep': 'compound', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}]}
 
 # Parsing result of "Who is the president of the United States?"
 def give_president_of_USA():
-    return  {'sentences': [{
-  'words': [
-    ['Who',
-      {'CharacterOffsetBegin': '0',
-       'PartOfSpeech': 'WP',
-       'Lemma': 'who',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '3'}],
-    ['is',
-      {'CharacterOffsetBegin': '4',
-       'PartOfSpeech': 'VBZ',
-       'Lemma': 'be',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '6'}],
-    ['the',
-      {'CharacterOffsetBegin': '7',
-       'PartOfSpeech': 'DT',
-       'Lemma': 'the',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '10'}],
-    ['president',
-      {'CharacterOffsetBegin': '11',
-       'PartOfSpeech': 'NN',
-       'Lemma': 'president',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '20'}],
-    ['of',
-      {'CharacterOffsetBegin': '21',
-       'PartOfSpeech': 'IN',
-       'Lemma': 'of',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '23'}],
-    ['the',
-      {'CharacterOffsetBegin': '24',
-       'PartOfSpeech': 'DT', 'Lemma':
-       'the', 'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '27'}],
-    ['United',
-      {'CharacterOffsetBegin': '28',
-       'PartOfSpeech': 'NNP',
-       'Lemma': 'United',
-       'NamedEntityTag': 'LOCATION',
-       'CharacterOffsetEnd': '34'}],
-    ['States',
-      {'CharacterOffsetBegin': '35',
-       'PartOfSpeech': 'NNPS',
-       'Lemma': 'States',
-       'NamedEntityTag': 'LOCATION',
-       'CharacterOffsetEnd': '41'}],
-    ['?',
-      {'CharacterOffsetBegin': '41',
-       'PartOfSpeech': '.',
-       'Lemma': '?',
-       'NamedEntityTag': 'O',
-       'CharacterOffsetEnd': '42'}]],
-  'text': 'Who is the president of the United States?',
-  'dependencies': [['root', 'ROOT', 'is'], ['dep', 'is', 'Who'], ['det', 'president', 'the'], ['nsubj', 'is', 'president'], ['det', 'States', 'the'], ['nn', 'States', 'United'], ['prep_of', 'president', 'States']],
-  'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['dep', 'is-2', 'Who-1'], ['det', 'president-4', 'the-3'], ['nsubj', 'is-2', 'president-4'], ['det', 'States-8', 'the-6'], ['nn', 'States-8', 'United-7'], ['prep_of', 'president-4', 'States-8']],
-  'parsetree': '(ROOT (SBARQ (WHNP (WP Who)) (SQ (VBZ is) (NP (NP (DT the) (NN president)) (PP (IN of) (NP (DT the) (NNP United) (NNPS States))))) (. ?)))'}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP Who))\n    (SQ (VBZ is)\n      (NP\n        (NP (DT the) (NN president))\n        (PP (IN of)\n          (NP (DT the) (NNP United) (NNPS States)))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 4}, {'governor': 8, 'dep': 'case', 'governorGloss': 'States', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 8, 'dep': 'det', 'governorGloss': 'States', 'dependentGloss': 'the', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'States', 'dependentGloss': 'United', 'dependent': 7}, {'governor': 4, 'dep': 'nmod', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 9}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 4}, {'governor': 8, 'dep': 'case', 'governorGloss': 'States', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 8, 'dep': 'det', 'governorGloss': 'States', 'dependentGloss': 'the', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'States', 'dependentGloss': 'United', 'dependent': 7}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 9}], 'tokens': [{'originalText': 'Who', 'characterOffsetEnd': 3, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'who', 'word': 'Who', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 6, 'pos': 'VBZ', 'characterOffsetBegin': 4, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 10, 'pos': 'DT', 'characterOffsetBegin': 7, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'president', 'characterOffsetEnd': 20, 'pos': 'NN', 'characterOffsetBegin': 11, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'president', 'word': 'president', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 23, 'pos': 'IN', 'characterOffsetBegin': 21, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 27, 'pos': 'DT', 'characterOffsetBegin': 24, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'United', 'characterOffsetEnd': 34, 'pos': 'NNP', 'characterOffsetBegin': 28, 'index': 7, 'after': ' ', 'before': ' ', 'lemma': 'United', 'word': 'United', 'ner': 'LOCATION'}, {'originalText': 'States', 'characterOffsetEnd': 41, 'pos': 'NNPS', 'characterOffsetBegin': 35, 'index': 8, 'after': '', 'before': ' ', 'lemma': 'States', 'word': 'States', 'ner': 'LOCATION'}, {'originalText': '?', 'characterOffsetEnd': 42, 'pos': '.', 'characterOffsetBegin': 41, 'index': 9, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'Who is the president of the United States?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'president', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'president', 'dependent': 4}, {'governor': 8, 'dep': 'case', 'governorGloss': 'States', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 8, 'dep': 'det', 'governorGloss': 'States', 'dependentGloss': 'the', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'States', 'dependentGloss': 'United', 'dependent': 7}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'president', 'dependentGloss': 'States', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 9}]}
 
 # Parsing result of "What was the first Gilbert and Sullivan opera?"
 def give_opera():
-    return  {'sentences': [{
-  'words': [
-    ['What',
-        {'PartOfSpeech': 'WP',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '0',
-         'Lemma': 'what',
-         'CharacterOffsetEnd': '4'}],
-    ['was',
-        {'PartOfSpeech': 'VBD',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '5',
-         'Lemma': 'be',
-         'CharacterOffsetEnd': '8'}],
-    ['the',
-        {'PartOfSpeech': 'DT',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '9',
-         'Lemma': 'the',
-         'CharacterOffsetEnd': '12'}],
-    ['first',
-        {'NamedEntityTag': 'ORDINAL',
-         'NormalizedNamedEntityTag': '1.0',
-         'CharacterOffsetEnd': '18',
-         'Lemma': 'first',
-         'CharacterOffsetBegin': '13',
-         'PartOfSpeech': 'JJ'}],
-    ['Gilbert',
-        {'PartOfSpeech': 'NNP',
-         'NamedEntityTag': 'PERSON',
-         'CharacterOffsetBegin': '19',
-         'Lemma': 'Gilbert',
-         'CharacterOffsetEnd': '26'}],
-    ['and',
-        {'PartOfSpeech': 'CC',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '27',
-         'Lemma': 'and',
-         'CharacterOffsetEnd': '30'}],
-    ['Sullivan',
-        {'PartOfSpeech': 'NNP',
-         'NamedEntityTag': 'PERSON',
-         'CharacterOffsetBegin': '31',
-         'Lemma': 'Sullivan',
-         'CharacterOffsetEnd': '39'}],
-    ['opera',
-        {'PartOfSpeech': 'NN',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '40',
-         'Lemma': 'opera',
-         'CharacterOffsetEnd': '45'}],
-    ['?',
-        {'PartOfSpeech': '.',
-         'NamedEntityTag': 'O',
-         'CharacterOffsetBegin': '45',
-         'Lemma': '?',
-         'CharacterOffsetEnd': '46'}]],
-  'text': 'What was the first Gilbert and Sullivan opera?',
-  'dependencies': [['root', 'ROOT', 'was'], ['dep', 'was', 'What'], ['det', 'Gilbert', 'the'], ['amod', 'Gilbert', 'first'], ['nsubj', 'was', 'Gilbert'], ['nn', 'opera', 'Sullivan'], ['conj_and', 'Gilbert', 'opera']],
-  'indexeddependencies': [['root', 'ROOT-0', 'was-2'], ['dep', 'was-2', 'What-1'], ['det', 'Gilbert-5', 'the-3'], ['amod', 'Gilbert-5', 'first-4'], ['nsubj', 'was-2', 'Gilbert-5'], ['nn', 'opera-8', 'Sullivan-7'], ['conj_and', 'Gilbert-5', 'opera-8']],
-  'parsetree': '(ROOT (SBARQ (WHNP (WP What)) (SQ (VBD was) (NP (DT the) (JJ first) (NNP Gilbert) (CC and) (NNP Sullivan) (NN opera))) (. ?)))'}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP What))\n    (SQ (VBD was)\n      (NP (DT the) (JJ first) (NNP Gilbert)\n        (CC and)\n        (NNP Sullivan) (NN opera)))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'was', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'was', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'Gilbert', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'Gilbert', 'dependentGloss': 'first', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'was', 'dependentGloss': 'Gilbert', 'dependent': 5}, {'governor': 5, 'dep': 'cc', 'governorGloss': 'Gilbert', 'dependentGloss': 'and', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'opera', 'dependentGloss': 'Sullivan', 'dependent': 7}, {'governor': 5, 'dep': 'conj', 'governorGloss': 'Gilbert', 'dependentGloss': 'opera', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'was', 'dependentGloss': '?', 'dependent': 9}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'was', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'was', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'Gilbert', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'Gilbert', 'dependentGloss': 'first', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'was', 'dependentGloss': 'Gilbert', 'dependent': 5}, {'governor': 5, 'dep': 'cc', 'governorGloss': 'Gilbert', 'dependentGloss': 'and', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'opera', 'dependentGloss': 'Sullivan', 'dependent': 7}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'was', 'dependentGloss': 'opera', 'dependent': 8}, {'governor': 5, 'dep': 'conj:and', 'governorGloss': 'Gilbert', 'dependentGloss': 'opera', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'was', 'dependentGloss': '?', 'dependent': 9}], 'tokens': [{'originalText': 'What', 'characterOffsetEnd': 4, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'what', 'word': 'What', 'ner': 'O'}, {'originalText': 'was', 'characterOffsetEnd': 8, 'pos': 'VBD', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'was', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 12, 'pos': 'DT', 'characterOffsetBegin': 9, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'first', 'characterOffsetEnd': 18, 'pos': 'JJ', 'characterOffsetBegin': 13, 'index': 4, 'normalizedNER': '1.0', 'before': ' ', 'after': ' ', 'lemma': 'first', 'word': 'first', 'ner': 'ORDINAL'}, {'originalText': 'Gilbert', 'characterOffsetEnd': 26, 'pos': 'NNP', 'characterOffsetBegin': 19, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'Gilbert', 'word': 'Gilbert', 'ner': 'PERSON'}, {'originalText': 'and', 'characterOffsetEnd': 30, 'pos': 'CC', 'characterOffsetBegin': 27, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'and', 'word': 'and', 'ner': 'O'}, {'originalText': 'Sullivan', 'characterOffsetEnd': 39, 'pos': 'NNP', 'characterOffsetBegin': 31, 'index': 7, 'after': ' ', 'before': ' ', 'lemma': 'Sullivan', 'word': 'Sullivan', 'ner': 'PERSON'}, {'originalText': 'opera', 'characterOffsetEnd': 45, 'pos': 'NN', 'characterOffsetBegin': 40, 'index': 8, 'after': '', 'before': ' ', 'lemma': 'opera', 'word': 'opera', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 46, 'pos': '.', 'characterOffsetBegin': 45, 'index': 9, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'What was the first Gilbert and Sullivan opera?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'was', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'was', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'Gilbert', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'Gilbert', 'dependentGloss': 'first', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'was', 'dependentGloss': 'Gilbert', 'dependent': 5}, {'governor': 5, 'dep': 'cc', 'governorGloss': 'Gilbert', 'dependentGloss': 'and', 'dependent': 6}, {'governor': 8, 'dep': 'compound', 'governorGloss': 'opera', 'dependentGloss': 'Sullivan', 'dependent': 7}, {'governor': 5, 'dep': 'conj:and', 'governorGloss': 'Gilbert', 'dependentGloss': 'opera', 'dependent': 8}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'was', 'dependentGloss': '?', 'dependent': 9}]}
 
 # Parsing result of "Who is the chief and prime minister?"
 def give_chief():
-    return  {'sentences': [{
-
-  'words': [
-    ['Who',
-        {'PartOfSpeech': 'WP',
-         'CharacterOffsetBegin': '0',
-         'CharacterOffsetEnd': '3',
-         'NamedEntityTag': 'O',
-         'Lemma': 'who'}],
-    ['is',
-        {'PartOfSpeech': 'VBZ',
-         'CharacterOffsetBegin': '4',
-         'CharacterOffsetEnd': '6',
-         'NamedEntityTag': 'O',
-         'Lemma': 'be'}],
-    ['the',
-        {'PartOfSpeech': 'DT',
-         'CharacterOffsetBegin': '7',
-         'CharacterOffsetEnd': '10',
-         'NamedEntityTag': 'O',
-         'Lemma': 'the'}],
-    ['chief',
-        {'PartOfSpeech': 'NN',
-         'CharacterOffsetBegin': '11',
-         'CharacterOffsetEnd': '16',
-         'NamedEntityTag': 'O',
-         'Lemma': 'chief'}],
-    ['and',
-        {'PartOfSpeech': 'CC',
-         'CharacterOffsetBegin': '17',
-         'CharacterOffsetEnd': '20',
-         'NamedEntityTag': 'O',
-         'Lemma': 'and'}],
-    ['prime',
-        {'PartOfSpeech': 'JJ',
-         'CharacterOffsetBegin': '21',
-         'CharacterOffsetEnd': '26',
-         'NamedEntityTag': 'O',
-         'Lemma': 'prime'}],
-    ['minister',
-        {'PartOfSpeech': 'NN',
-         'CharacterOffsetBegin': '27',
-         'CharacterOffsetEnd': '35',
-         'NamedEntityTag': 'O',
-         'Lemma': 'minister'}],
-    ['?',
-        {'PartOfSpeech': '.',
-         'CharacterOffsetBegin': '35',
-         'CharacterOffsetEnd': '36',
-         'NamedEntityTag': 'O',
-         'Lemma': '?'}]],
-   'parsetree': '(ROOT (SBARQ (WHNP (WP Who)) (SQ (VBZ is) (NP (NP (DT the) (NN chief)) (CC and) (NP (JJ prime) (NN minister)))) (. ?)))',
-  'dependencies': [['root', 'ROOT', 'is'], ['dep', 'is', 'Who'], ['det', 'chief', 'the'], ['nsubj', 'is', 'chief'], ['amod', 'minister', 'prime'], ['conj_and', 'chief', 'minister']],
-  'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['dep', 'is-2', 'Who-1'], ['det', 'chief-4', 'the-3'], ['nsubj', 'is-2', 'chief-4'], ['amod', 'minister-7', 'prime-6'], ['conj_and', 'chief-4', 'minister-7']],
-  'text': 'Who is the chief and prime minister?'}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP Who))\n    (SQ (VBZ is)\n      (NP\n        (NP (DT the) (NN chief))\n        (CC and)\n        (NP (JJ prime) (NN minister))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'chief', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'chief', 'dependent': 4}, {'governor': 4, 'dep': 'cc', 'governorGloss': 'chief', 'dependentGloss': 'and', 'dependent': 5}, {'governor': 7, 'dep': 'amod', 'governorGloss': 'minister', 'dependentGloss': 'prime', 'dependent': 6}, {'governor': 4, 'dep': 'conj', 'governorGloss': 'chief', 'dependentGloss': 'minister', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'chief', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'chief', 'dependent': 4}, {'governor': 4, 'dep': 'cc', 'governorGloss': 'chief', 'dependentGloss': 'and', 'dependent': 5}, {'governor': 7, 'dep': 'amod', 'governorGloss': 'minister', 'dependentGloss': 'prime', 'dependent': 6}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'minister', 'dependent': 7}, {'governor': 4, 'dep': 'conj:and', 'governorGloss': 'chief', 'dependentGloss': 'minister', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'tokens': [{'originalText': 'Who', 'characterOffsetEnd': 3, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'who', 'word': 'Who', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 6, 'pos': 'VBZ', 'characterOffsetBegin': 4, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 10, 'pos': 'DT', 'characterOffsetBegin': 7, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'chief', 'characterOffsetEnd': 16, 'pos': 'NN', 'characterOffsetBegin': 11, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'chief', 'word': 'chief', 'ner': 'O'}, {'originalText': 'and', 'characterOffsetEnd': 20, 'pos': 'CC', 'characterOffsetBegin': 17, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'and', 'word': 'and', 'ner': 'O'}, {'originalText': 'prime', 'characterOffsetEnd': 26, 'pos': 'JJ', 'characterOffsetBegin': 21, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'prime', 'word': 'prime', 'ner': 'O'}, {'originalText': 'minister', 'characterOffsetEnd': 35, 'pos': 'NN', 'characterOffsetBegin': 27, 'index': 7, 'after': '', 'before': ' ', 'lemma': 'minister', 'word': 'minister', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 36, 'pos': '.', 'characterOffsetBegin': 35, 'index': 8, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'Who is the chief and prime minister?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'Who', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'chief', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'chief', 'dependent': 4}, {'governor': 4, 'dep': 'cc', 'governorGloss': 'chief', 'dependentGloss': 'and', 'dependent': 5}, {'governor': 7, 'dep': 'amod', 'governorGloss': 'minister', 'dependentGloss': 'prime', 'dependent': 6}, {'governor': 4, 'dep': 'conj:and', 'governorGloss': 'chief', 'dependentGloss': 'minister', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}]}
 
 # Parsing result of "Is born in 1900"
 def give_born():
-    return {'sentences': [{'indexeddependencies': [['root', 'ROOT-0', 'born-2'], ['auxpass', 'born-2', 'Is-1'], ['prep_in', 'born-2', '1900-4']], 'parsetree': '(ROOT (FRAG (VP (VBZ Is) (VP (VBN born) (PP (IN in) (NP (CD 1900)))))))', 'words': [['Is', {'PartOfSpeech': 'VBZ', 'Lemma': 'be', 'CharacterOffsetBegin': '0', 'CharacterOffsetEnd': '2', 'NamedEntityTag': 'O'}], ['born', {'PartOfSpeech': 'VBN', 'Lemma': 'bear', 'CharacterOffsetBegin': '3', 'CharacterOffsetEnd': '7', 'NamedEntityTag': 'O'}], ['in', {'PartOfSpeech': 'IN', 'Lemma': 'in', 'CharacterOffsetBegin': '8', 'CharacterOffsetEnd': '10', 'NamedEntityTag': 'O'}], ['1900', {'Timex': '<TIMEX3 tid="t1" type="DATE" value="1900">1900</TIMEX3>', 'PartOfSpeech': 'CD', 'Lemma': '1900', 'NamedEntityTag': 'DATE', 'CharacterOffsetBegin': '11', 'CharacterOffsetEnd': '15', 'NormalizedNamedEntityTag': '1900'}]], 'dependencies': [['root', 'ROOT', 'born'], ['auxpass', 'born', 'Is'], ['prep_in', 'born', '1900']], 'text': 'Is born in 1900'}]}
+    return {'parse': '(ROOT\n  (FRAG\n    (VP (VBZ Is)\n      (VP (VBN born)\n        (PP (IN in)\n          (NP (CD 1900)))))))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 2}, {'governor': 2, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 4, 'dep': 'case', 'governorGloss': '1900', 'dependentGloss': 'in', 'dependent': 3}, {'governor': 2, 'dep': 'nmod', 'governorGloss': 'born', 'dependentGloss': '1900', 'dependent': 4}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 2}, {'governor': 2, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 4, 'dep': 'case', 'governorGloss': '1900', 'dependentGloss': 'in', 'dependent': 3}, {'governor': 2, 'dep': 'nmod:in', 'governorGloss': 'born', 'dependentGloss': '1900', 'dependent': 4}], 'tokens': [{'originalText': 'Is', 'characterOffsetEnd': 2, 'pos': 'VBZ', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'be', 'word': 'Is', 'ner': 'O'}, {'originalText': 'born', 'characterOffsetEnd': 7, 'pos': 'VBN', 'characterOffsetBegin': 3, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'bear', 'word': 'born', 'ner': 'O'}, {'originalText': 'in', 'characterOffsetEnd': 10, 'pos': 'IN', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'in', 'word': 'in', 'ner': 'O'}, {'originalText': '1900', 'characterOffsetEnd': 15, 'pos': 'CD', 'characterOffsetBegin': 11, 'index': 4, 'normalizedNER': '1900', 'before': ' ', 'after': '', 'lemma': '1900', 'word': '1900', 'ner': 'DATE'}], 'text': 'Is born in 1900', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 2}, {'governor': 2, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 4, 'dep': 'case', 'governorGloss': '1900', 'dependentGloss': 'in', 'dependent': 3}, {'governor': 2, 'dep': 'nmod:in', 'governorGloss': 'born', 'dependentGloss': '1900', 'dependent': 4}]}
 
 # Parsing result of "President of France"
 def birth_date():
-    return {'sentences': [{'parsetree': '(ROOT (NP (NP (NNP President)) (PP (IN of) (NP (NNP France)))))', 'words': [['President', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '0', 'Lemma': 'President', 'CharacterOffsetEnd': '9', 'PartOfSpeech': 'NNP'}], ['of', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '10', 'Lemma': 'of', 'CharacterOffsetEnd': '12', 'PartOfSpeech': 'IN'}], ['France', {'NamedEntityTag': 'LOCATION', 'CharacterOffsetBegin': '13', 'Lemma': 'France', 'CharacterOffsetEnd': '19', 'PartOfSpeech': 'NNP'}]], 'dependencies': [['root', 'ROOT', 'President'], ['prep_of', 'President', 'France']], 'text': 'President of France', 'indexeddependencies': [['root', 'ROOT-0', 'President-1'], ['prep_of', 'President-1', 'France-3']]}]}
+    return {'parse': '(ROOT\n  (NP\n    (NP (NNP President))\n    (PP (IN of)\n      (NP (NNP France)))))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'President', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod', 'governorGloss': 'President', 'dependentGloss': 'France', 'dependent': 3}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'President', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod:of', 'governorGloss': 'President', 'dependentGloss': 'France', 'dependent': 3}], 'tokens': [{'originalText': 'President', 'characterOffsetEnd': 9, 'pos': 'NNP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'President', 'word': 'President', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 12, 'pos': 'IN', 'characterOffsetBegin': 10, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'France', 'characterOffsetEnd': 19, 'pos': 'NNP', 'characterOffsetBegin': 13, 'index': 3, 'after': '', 'before': ' ', 'lemma': 'France', 'word': 'France', 'ner': 'LOCATION'}], 'text': 'President of France', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'President', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod:of', 'governorGloss': 'President', 'dependentGloss': 'France', 'dependent': 3}]}
 
 # Parsing result of "When is born Obama?"
 def birth_place():
-    return {'sentences': [{'dependencies': [['root', 'ROOT', 'born'], ['advmod', 'born', 'When'], ['auxpass', 'born', 'is'], ['dobj', 'born', 'Obama']], 'words': [['When', {'Lemma': 'when', 'CharacterOffsetEnd': '4', 'NamedEntityTag': 'O', 'PartOfSpeech': 'WRB', 'CharacterOffsetBegin': '0'}], ['is', {'Lemma': 'be', 'CharacterOffsetEnd': '7', 'NamedEntityTag': 'O', 'PartOfSpeech': 'VBZ', 'CharacterOffsetBegin': '5'}], ['born', {'Lemma': 'bear', 'CharacterOffsetEnd': '12', 'NamedEntityTag': 'O', 'PartOfSpeech': 'VBN', 'CharacterOffsetBegin': '8'}], ['Obama', {'Lemma': 'Obama', 'CharacterOffsetEnd': '18', 'NamedEntityTag': 'PERSON', 'PartOfSpeech': 'NNP', 'CharacterOffsetBegin': '13'}], ['?', {'Lemma': '?', 'CharacterOffsetEnd': '19', 'NamedEntityTag': 'O', 'PartOfSpeech': '.', 'CharacterOffsetBegin': '18'}]], 'text': 'When is born Obama?', 'indexeddependencies': [['root', 'ROOT-0', 'born-3'], ['advmod', 'born-3', 'When-1'], ['auxpass', 'born-3', 'is-2'], ['dobj', 'born-3', 'Obama-4']], 'parsetree': '(ROOT (SBARQ (WHADVP (WRB When)) (SQ (VBZ is) (VP (VBN born) (NP (NNP Obama)))) (. ?)))'}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHADVP (WRB When))\n    (SQ (VBZ is)\n      (VP (VBN born)\n        (NP (NNP Obama))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 3}, {'governor': 3, 'dep': 'advmod', 'governorGloss': 'born', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 3, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 3, 'dep': 'dobj', 'governorGloss': 'born', 'dependentGloss': 'Obama', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'born', 'dependentGloss': '?', 'dependent': 5}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 3}, {'governor': 3, 'dep': 'advmod', 'governorGloss': 'born', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 3, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 3, 'dep': 'dobj', 'governorGloss': 'born', 'dependentGloss': 'Obama', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'born', 'dependentGloss': '?', 'dependent': 5}], 'tokens': [{'originalText': 'When', 'characterOffsetEnd': 4, 'pos': 'WRB', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'when', 'word': 'When', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 7, 'pos': 'VBZ', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'born', 'characterOffsetEnd': 12, 'pos': 'VBN', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'bear', 'word': 'born', 'ner': 'O'}, {'originalText': 'Obama', 'characterOffsetEnd': 18, 'pos': 'NNP', 'characterOffsetBegin': 13, 'index': 4, 'after': '', 'before': ' ', 'lemma': 'Obama', 'word': 'Obama', 'ner': 'PERSON'}, {'originalText': '?', 'characterOffsetEnd': 19, 'pos': '.', 'characterOffsetBegin': 18, 'index': 5, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'When is born Obama?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'born', 'dependent': 3}, {'governor': 3, 'dep': 'advmod', 'governorGloss': 'born', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 3, 'dep': 'auxpass', 'governorGloss': 'born', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 3, 'dep': 'dobj', 'governorGloss': 'born', 'dependentGloss': 'Obama', 'dependent': 4}, {'governor': 3, 'dep': 'punct', 'governorGloss': 'born', 'dependentGloss': '?', 'dependent': 5}]}
 
 # Parsing result of "Where is the mistake the mistake?"
-
 def mistake():
-    return {'sentences': [{'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['advmod', 'is-2', 'Where-1'], ['det', 'mistake-4', 'the-3'], ['nsubj', 'is-2', 'mistake-4'], ['det', 'mistake-6', 'the-5'], ['dep', 'mistake-4', 'mistake-6']], 'dependencies': [['root', 'ROOT', 'is'], ['advmod', 'is', 'Where'], ['det', 'mistake', 'the'], ['nsubj', 'is', 'mistake'], ['det', 'mistake', 'the'], ['dep', 'mistake', 'mistake']], 'parsetree': '(ROOT (SBARQ (WHADVP (WRB Where)) (SQ (VBZ is) (NP (DT the) (NN mistake) (NP (DT the) (NN mistake)))) (. ?)))', 'text': 'Where is the mistake the mistake?', 'words': [['Where', {'PartOfSpeech': 'WRB', 'CharacterOffsetEnd': '5', 'CharacterOffsetBegin': '0', 'NamedEntityTag': 'O', 'Lemma': 'where'}], ['is', {'PartOfSpeech': 'VBZ', 'CharacterOffsetEnd': '8', 'CharacterOffsetBegin': '6', 'NamedEntityTag': 'O', 'Lemma': 'be'}], ['the', {'PartOfSpeech': 'DT', 'CharacterOffsetEnd': '12', 'CharacterOffsetBegin': '9', 'NamedEntityTag': 'O', 'Lemma': 'the'}], ['mistake', {'PartOfSpeech': 'NN', 'CharacterOffsetEnd': '20', 'CharacterOffsetBegin': '13', 'NamedEntityTag': 'O', 'Lemma': 'mistake'}], ['the', {'PartOfSpeech': 'DT', 'CharacterOffsetEnd': '24', 'CharacterOffsetBegin': '21', 'NamedEntityTag': 'O', 'Lemma': 'the'}], ['mistake', {'PartOfSpeech': 'NN', 'CharacterOffsetEnd': '32', 'CharacterOffsetBegin': '25', 'NamedEntityTag': 'O', 'Lemma': 'mistake'}], ['?', {'PartOfSpeech': '.', 'CharacterOffsetEnd': '33', 'CharacterOffsetBegin': '32', 'NamedEntityTag': 'O', 'Lemma': '?'}]]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHADVP (WRB Where))\n    (SQ (VBZ is)\n      (NP (DT the) (NN mistake)\n        (NP (DT the) (NN mistake))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'Where', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mistake', 'dependent': 4}, {'governor': 6, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 5}, {'governor': 4, 'dep': 'dep', 'governorGloss': 'mistake', 'dependentGloss': 'mistake', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'Where', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mistake', 'dependent': 4}, {'governor': 6, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 5}, {'governor': 4, 'dep': 'dep', 'governorGloss': 'mistake', 'dependentGloss': 'mistake', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}], 'tokens': [{'originalText': 'Where', 'characterOffsetEnd': 5, 'pos': 'WRB', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'where', 'word': 'Where', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 8, 'pos': 'VBZ', 'characterOffsetBegin': 6, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 12, 'pos': 'DT', 'characterOffsetBegin': 9, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'mistake', 'characterOffsetEnd': 20, 'pos': 'NN', 'characterOffsetBegin': 13, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'mistake', 'word': 'mistake', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 24, 'pos': 'DT', 'characterOffsetBegin': 21, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'mistake', 'characterOffsetEnd': 32, 'pos': 'NN', 'characterOffsetBegin': 25, 'index': 6, 'after': '', 'before': ' ', 'lemma': 'mistake', 'word': 'mistake', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 33, 'pos': '.', 'characterOffsetBegin': 32, 'index': 7, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'Where is the mistake the mistake?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'Where', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mistake', 'dependent': 4}, {'governor': 6, 'dep': 'det', 'governorGloss': 'mistake', 'dependentGloss': 'the', 'dependent': 5}, {'governor': 4, 'dep': 'dep', 'governorGloss': 'mistake', 'dependentGloss': 'mistake', 'dependent': 6}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 7}]}
 
 # Parsing result of "What is the highest mountain of Tanzania?"
 def tanzania():
-    return {'sentences': [{'text': 'What is the highest mountain of Tanzania?', 'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['dep', 'is-2', 'What-1'], ['det', 'mountain-5', 'the-3'], ['amod', 'mountain-5', 'highest-4'], ['nsubj', 'is-2', 'mountain-5'], ['prep_of', 'mountain-5', 'Tanzania-7']], 'parsetree': '(ROOT (SBARQ (WHNP (WP What)) (SQ (VBZ is) (NP (NP (DT the) (JJS highest) (NN mountain)) (PP (IN of) (NP (NNP Tanzania))))) (. ?)))', 'words': [['What', {'CharacterOffsetBegin': '0', 'Lemma': 'what', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '4', 'PartOfSpeech': 'WP'}], ['is', {'CharacterOffsetBegin': '5', 'Lemma': 'be', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '7', 'PartOfSpeech': 'VBZ'}], ['the', {'CharacterOffsetBegin': '8', 'Lemma': 'the', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '11', 'PartOfSpeech': 'DT'}], ['highest', {'CharacterOffsetBegin': '12', 'Lemma': 'highest', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '19', 'PartOfSpeech': 'JJS'}], ['mountain', {'CharacterOffsetBegin': '20', 'Lemma': 'mountain', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '28', 'PartOfSpeech': 'NN'}], ['of', {'CharacterOffsetBegin': '29', 'Lemma': 'of', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '31', 'PartOfSpeech': 'IN'}], ['Tanzania', {'CharacterOffsetBegin': '32', 'Lemma': 'Tanzania', 'NamedEntityTag': 'LOCATION', 'CharacterOffsetEnd': '40', 'PartOfSpeech': 'NNP'}], ['?', {'CharacterOffsetBegin': '40', 'Lemma': '?', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '41', 'PartOfSpeech': '.'}]], 'dependencies': [['root', 'ROOT', 'is'], ['dep', 'is', 'What'], ['det', 'mountain', 'the'], ['amod', 'mountain', 'highest'], ['nsubj', 'is', 'mountain'], ['prep_of', 'mountain', 'Tanzania']]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP What))\n    (SQ (VBZ is)\n      (NP\n        (NP (DT the) (JJS highest) (NN mountain))\n        (PP (IN of)\n          (NP (NNP Tanzania)))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'mountain', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'mountain', 'dependentGloss': 'highest', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mountain', 'dependent': 5}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Tanzania', 'dependentGloss': 'of', 'dependent': 6}, {'governor': 5, 'dep': 'nmod', 'governorGloss': 'mountain', 'dependentGloss': 'Tanzania', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'mountain', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'mountain', 'dependentGloss': 'highest', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mountain', 'dependent': 5}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Tanzania', 'dependentGloss': 'of', 'dependent': 6}, {'governor': 5, 'dep': 'nmod:of', 'governorGloss': 'mountain', 'dependentGloss': 'Tanzania', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'tokens': [{'originalText': 'What', 'characterOffsetEnd': 4, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'what', 'word': 'What', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 7, 'pos': 'VBZ', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 11, 'pos': 'DT', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'highest', 'characterOffsetEnd': 19, 'pos': 'JJS', 'characterOffsetBegin': 12, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'highest', 'word': 'highest', 'ner': 'O'}, {'originalText': 'mountain', 'characterOffsetEnd': 28, 'pos': 'NN', 'characterOffsetBegin': 20, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'mountain', 'word': 'mountain', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 31, 'pos': 'IN', 'characterOffsetBegin': 29, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'Tanzania', 'characterOffsetEnd': 40, 'pos': 'NNP', 'characterOffsetBegin': 32, 'index': 7, 'after': '', 'before': ' ', 'lemma': 'Tanzania', 'word': 'Tanzania', 'ner': 'LOCATION'}, {'originalText': '?', 'characterOffsetEnd': 41, 'pos': '.', 'characterOffsetBegin': 40, 'index': 8, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'What is the highest mountain of Tanzania?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 5, 'dep': 'det', 'governorGloss': 'mountain', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'amod', 'governorGloss': 'mountain', 'dependentGloss': 'highest', 'dependent': 4}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'mountain', 'dependent': 5}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Tanzania', 'dependentGloss': 'of', 'dependent': 6}, {'governor': 5, 'dep': 'nmod:of', 'governorGloss': 'mountain', 'dependentGloss': 'Tanzania', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}]}
 
 # Parsing result of "When is the birthday of Mickey Mouse?"
 def mickey():
-    return {'sentences': [{'parsetree': '(ROOT (SBARQ (WHADVP (WRB When)) (SQ (VBZ is) (NP (NP (DT the) (NN birthday)) (PP (IN of) (NP (NNP Mickey) (NNP Mouse))))) (. ?)))', 'dependencies': [['root', 'ROOT', 'is'], ['advmod', 'is', 'When'], ['det', 'birthday', 'the'], ['nsubj', 'is', 'birthday'], ['nn', 'Mouse', 'Mickey'], ['prep_of', 'birthday', 'Mouse']], 'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['advmod', 'is-2', 'When-1'], ['det', 'birthday-4', 'the-3'], ['nsubj', 'is-2', 'birthday-4'], ['nn', 'Mouse-7', 'Mickey-6'], ['prep_of', 'birthday-4', 'Mouse-7']], 'text': 'When is the birthday of Mickey Mouse?', 'words': [['When', {'CharacterOffsetBegin': '0', 'CharacterOffsetEnd': '4', 'PartOfSpeech': 'WRB', 'NamedEntityTag': 'O', 'Lemma': 'when'}], ['is', {'CharacterOffsetBegin': '5', 'CharacterOffsetEnd': '7', 'PartOfSpeech': 'VBZ', 'NamedEntityTag': 'O', 'Lemma': 'be'}], ['the', {'CharacterOffsetBegin': '8', 'CharacterOffsetEnd': '11', 'PartOfSpeech': 'DT', 'NamedEntityTag': 'O', 'Lemma': 'the'}], ['birthday', {'CharacterOffsetBegin': '12', 'CharacterOffsetEnd': '20', 'PartOfSpeech': 'NN', 'NamedEntityTag': 'O', 'Lemma': 'birthday'}], ['of', {'CharacterOffsetBegin': '21', 'CharacterOffsetEnd': '23', 'PartOfSpeech': 'IN', 'NamedEntityTag': 'O', 'Lemma': 'of'}], ['Mickey', {'CharacterOffsetBegin': '24', 'CharacterOffsetEnd': '30', 'PartOfSpeech': 'NNP', 'NamedEntityTag': 'PERSON', 'Lemma': 'Mickey'}], ['Mouse', {'CharacterOffsetBegin': '31', 'CharacterOffsetEnd': '36', 'PartOfSpeech': 'NNP', 'NamedEntityTag': 'PERSON', 'Lemma': 'Mouse'}], ['?', {'CharacterOffsetBegin': '36', 'CharacterOffsetEnd': '37', 'PartOfSpeech': '.', 'NamedEntityTag': 'O', 'Lemma': '?'}]]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHADVP (WRB When))\n    (SQ (VBZ is)\n      (NP\n        (NP (DT the) (NN birthday))\n        (PP (IN of)\n          (NP (NNP Mickey) (NNP Mouse)))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'birthday', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'birthday', 'dependent': 4}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Mouse', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 7, 'dep': 'compound', 'governorGloss': 'Mouse', 'dependentGloss': 'Mickey', 'dependent': 6}, {'governor': 4, 'dep': 'nmod', 'governorGloss': 'birthday', 'dependentGloss': 'Mouse', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'birthday', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'birthday', 'dependent': 4}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Mouse', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 7, 'dep': 'compound', 'governorGloss': 'Mouse', 'dependentGloss': 'Mickey', 'dependent': 6}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'birthday', 'dependentGloss': 'Mouse', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}], 'tokens': [{'originalText': 'When', 'characterOffsetEnd': 4, 'pos': 'WRB', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'when', 'word': 'When', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 7, 'pos': 'VBZ', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 11, 'pos': 'DT', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'birthday', 'characterOffsetEnd': 20, 'pos': 'NN', 'characterOffsetBegin': 12, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'birthday', 'word': 'birthday', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 23, 'pos': 'IN', 'characterOffsetBegin': 21, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'Mickey', 'characterOffsetEnd': 30, 'pos': 'NNP', 'characterOffsetBegin': 24, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'Mickey', 'word': 'Mickey', 'ner': 'PERSON'}, {'originalText': 'Mouse', 'characterOffsetEnd': 36, 'pos': 'NNP', 'characterOffsetBegin': 31, 'index': 7, 'after': '', 'before': ' ', 'lemma': 'Mouse', 'word': 'Mouse', 'ner': 'PERSON'}, {'originalText': '?', 'characterOffsetEnd': 37, 'pos': '.', 'characterOffsetBegin': 36, 'index': 8, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'When is the birthday of Mickey Mouse?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'advmod', 'governorGloss': 'is', 'dependentGloss': 'When', 'dependent': 1}, {'governor': 4, 'dep': 'det', 'governorGloss': 'birthday', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'birthday', 'dependent': 4}, {'governor': 7, 'dep': 'case', 'governorGloss': 'Mouse', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 7, 'dep': 'compound', 'governorGloss': 'Mouse', 'dependentGloss': 'Mickey', 'dependent': 6}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'birthday', 'dependentGloss': 'Mouse', 'dependent': 7}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 8}]}
 
 # Parsing result of "What is black and white?"
 def black():
-    return {'sentences': [{'dependencies': [['root', 'ROOT', 'black'], ['dep', 'black', 'What'], ['cop', 'black', 'is'], ['conj_and', 'black', 'white']], 'indexeddependencies': [['root', 'ROOT-0', 'black-3'], ['dep', 'black-3', 'What-1'], ['cop', 'black-3', 'is-2'], ['conj_and', 'black-3', 'white-5']], 'parsetree': '(ROOT (SBARQ (WHNP (WP What)) (SQ (VBZ is) (ADJP (JJ black) (CC and) (JJ white))) (. ?)))', 'text': 'What is black and white?', 'words': [['What', {'Lemma': 'what', 'NamedEntityTag': 'O', 'PartOfSpeech': 'WP', 'CharacterOffsetEnd': '4', 'CharacterOffsetBegin': '0'}], ['is', {'Lemma': 'be', 'NamedEntityTag': 'O', 'PartOfSpeech': 'VBZ', 'CharacterOffsetEnd': '7', 'CharacterOffsetBegin': '5'}], ['black', {'Lemma': 'black', 'NamedEntityTag': 'O', 'PartOfSpeech': 'JJ', 'CharacterOffsetEnd': '13', 'CharacterOffsetBegin': '8'}], ['and', {'Lemma': 'and', 'NamedEntityTag': 'O', 'PartOfSpeech': 'CC', 'CharacterOffsetEnd': '17', 'CharacterOffsetBegin': '14'}], ['white', {'Lemma': 'white', 'NamedEntityTag': 'O', 'PartOfSpeech': 'JJ', 'CharacterOffsetEnd': '23', 'CharacterOffsetBegin': '18'}], ['?', {'Lemma': '?', 'NamedEntityTag': 'O', 'PartOfSpeech': '.', 'CharacterOffsetEnd': '24', 'CharacterOffsetBegin': '23'}]]}]}
+    return {'index': 0, 'text': 'What is black and white?', 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'dependent': 3, 'governorGloss': 'ROOT', 'dependentGloss': 'black'}, {'governor': 3, 'dep': 'nsubj', 'dependent': 1, 'governorGloss': 'black', 'dependentGloss': 'What'}, {'governor': 3, 'dep': 'cop', 'dependent': 2, 'governorGloss': 'black', 'dependentGloss': 'is'}, {'governor': 3, 'dep': 'cc', 'dependent': 4, 'governorGloss': 'black', 'dependentGloss': 'and'}, {'governor': 3, 'dep': 'conj:and', 'dependent': 5, 'governorGloss': 'black', 'dependentGloss': 'white'}, {'governor': 3, 'dep': 'punct', 'dependent': 6, 'governorGloss': 'black', 'dependentGloss': '?'}], 'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP What))\n    (SQ (VBZ is)\n      (ADJP (JJ black)\n        (CC and)\n        (JJ white)))\n    (. ?)))', 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'dependent': 3, 'governorGloss': 'ROOT', 'dependentGloss': 'black'}, {'governor': 3, 'dep': 'nsubj', 'dependent': 1, 'governorGloss': 'black', 'dependentGloss': 'What'}, {'governor': 5, 'dep': 'nsubj', 'dependent': 1, 'governorGloss': 'white', 'dependentGloss': 'What'}, {'governor': 3, 'dep': 'cop', 'dependent': 2, 'governorGloss': 'black', 'dependentGloss': 'is'}, {'governor': 3, 'dep': 'cc', 'dependent': 4, 'governorGloss': 'black', 'dependentGloss': 'and'}, {'governor': 3, 'dep': 'conj:and', 'dependent': 5, 'governorGloss': 'black', 'dependentGloss': 'white'}, {'governor': 3, 'dep': 'punct', 'dependent': 6, 'governorGloss': 'black', 'dependentGloss': '?'}], 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'dependent': 3, 'governorGloss': 'ROOT', 'dependentGloss': 'black'}, {'governor': 3, 'dep': 'nsubj', 'dependent': 1, 'governorGloss': 'black', 'dependentGloss': 'What'}, {'governor': 3, 'dep': 'cop', 'dependent': 2, 'governorGloss': 'black', 'dependentGloss': 'is'}, {'governor': 3, 'dep': 'cc', 'dependent': 4, 'governorGloss': 'black', 'dependentGloss': 'and'}, {'governor': 3, 'dep': 'conj', 'dependent': 5, 'governorGloss': 'black', 'dependentGloss': 'white'}, {'governor': 3, 'dep': 'punct', 'dependent': 6, 'governorGloss': 'black', 'dependentGloss': '?'}], 'tokens': [{'lemma': 'what', 'characterOffsetBegin': 0, 'index': 1, 'pos': 'WP', 'characterOffsetEnd': 4, 'after': ' ', 'originalText': 'What', 'word': 'What', 'ner': 'O', 'before': ''}, {'lemma': 'be', 'characterOffsetBegin': 5, 'index': 2, 'pos': 'VBZ', 'characterOffsetEnd': 7, 'after': ' ', 'originalText': 'is', 'word': 'is', 'ner': 'O', 'before': ' '}, {'lemma': 'black', 'characterOffsetBegin': 8, 'index': 3, 'pos': 'JJ', 'characterOffsetEnd': 13, 'after': ' ', 'originalText': 'black', 'word': 'black', 'ner': 'O', 'before': ' '}, {'lemma': 'and', 'characterOffsetBegin': 14, 'index': 4, 'pos': 'CC', 'characterOffsetEnd': 17, 'after': ' ', 'originalText': 'and', 'word': 'and', 'ner': 'O', 'before': ' '}, {'lemma': 'white', 'characterOffsetBegin': 18, 'index': 5, 'pos': 'JJ', 'characterOffsetEnd': 23, 'after': '', 'originalText': 'white', 'word': 'white', 'ner': 'O', 'before': ' '}, {'lemma': '?', 'characterOffsetBegin': 23, 'index': 6, 'pos': '.', 'characterOffsetEnd': 24, 'after': '', 'originalText': '?', 'word': '?', 'ner': 'O', 'before': ''}]}
 
 # Parsing result of "Is there a king of England?"
 def king_england():
-    return {'sentences': [{'parsetree': '(ROOT (SQ (VBZ Is) (NP (EX there)) (NP (NP (DT a) (NN king)) (PP (IN of) (NP (NNP England)))) (. ?)))', 'words': [['Is', {'Lemma': 'be', 'PartOfSpeech': 'VBZ', 'CharacterOffsetBegin': '0', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '2'}], ['there', {'Lemma': 'there', 'PartOfSpeech': 'EX', 'CharacterOffsetBegin': '3', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '8'}], ['a', {'Lemma': 'a', 'PartOfSpeech': 'DT', 'CharacterOffsetBegin': '9', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '10'}], ['king', {'Lemma': 'king', 'PartOfSpeech': 'NN', 'CharacterOffsetBegin': '11', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '15'}], ['of', {'Lemma': 'of', 'PartOfSpeech': 'IN', 'CharacterOffsetBegin': '16', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '18'}], ['England', {'Lemma': 'England', 'PartOfSpeech': 'NNP', 'CharacterOffsetBegin': '19', 'NamedEntityTag': 'LOCATION', 'CharacterOffsetEnd': '26'}], ['?', {'Lemma': '?', 'PartOfSpeech': '.', 'CharacterOffsetBegin': '26', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '27'}]], 'indexeddependencies': [['root', 'ROOT-0', 'Is-1'], ['expl', 'Is-1', 'there-2'], ['det', 'king-4', 'a-3'], ['nsubj', 'Is-1', 'king-4'], ['prep_of', 'king-4', 'England-6']], 'text': 'Is there a king of England?', 'dependencies': [['root', 'ROOT', 'Is'], ['expl', 'Is', 'there'], ['det', 'king', 'a'], ['nsubj', 'Is', 'king'], ['prep_of', 'king', 'England']]}]}
+    return {'parse': '(ROOT\n  (SQ (VBZ Is)\n    (NP (EX there))\n    (NP\n      (NP (DT a) (NN king))\n      (PP (IN of)\n        (NP (NNP England))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 1, 'dep': 'expl', 'governorGloss': 'Is', 'dependentGloss': 'there', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'king', 'dependentGloss': 'a', 'dependent': 3}, {'governor': 1, 'dep': 'nsubj', 'governorGloss': 'Is', 'dependentGloss': 'king', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'England', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod', 'governorGloss': 'king', 'dependentGloss': 'England', 'dependent': 6}, {'governor': 1, 'dep': 'punct', 'governorGloss': 'Is', 'dependentGloss': '?', 'dependent': 7}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 1, 'dep': 'expl', 'governorGloss': 'Is', 'dependentGloss': 'there', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'king', 'dependentGloss': 'a', 'dependent': 3}, {'governor': 1, 'dep': 'nsubj', 'governorGloss': 'Is', 'dependentGloss': 'king', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'England', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'king', 'dependentGloss': 'England', 'dependent': 6}, {'governor': 1, 'dep': 'punct', 'governorGloss': 'Is', 'dependentGloss': '?', 'dependent': 7}], 'tokens': [{'originalText': 'Is', 'characterOffsetEnd': 2, 'pos': 'VBZ', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'be', 'word': 'Is', 'ner': 'O'}, {'originalText': 'there', 'characterOffsetEnd': 8, 'pos': 'EX', 'characterOffsetBegin': 3, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'there', 'word': 'there', 'ner': 'O'}, {'originalText': 'a', 'characterOffsetEnd': 10, 'pos': 'DT', 'characterOffsetBegin': 9, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'a', 'word': 'a', 'ner': 'O'}, {'originalText': 'king', 'characterOffsetEnd': 15, 'pos': 'NN', 'characterOffsetBegin': 11, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'king', 'word': 'king', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 18, 'pos': 'IN', 'characterOffsetBegin': 16, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'England', 'characterOffsetEnd': 26, 'pos': 'NNP', 'characterOffsetBegin': 19, 'index': 6, 'after': '', 'before': ' ', 'lemma': 'England', 'word': 'England', 'ner': 'LOCATION'}, {'originalText': '?', 'characterOffsetEnd': 27, 'pos': '.', 'characterOffsetBegin': 26, 'index': 7, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'Is there a king of England?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Is', 'dependent': 1}, {'governor': 1, 'dep': 'expl', 'governorGloss': 'Is', 'dependentGloss': 'there', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'king', 'dependentGloss': 'a', 'dependent': 3}, {'governor': 1, 'dep': 'nsubj', 'governorGloss': 'Is', 'dependentGloss': 'king', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'England', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'king', 'dependentGloss': 'England', 'dependent': 6}, {'governor': 1, 'dep': 'punct', 'governorGloss': 'Is', 'dependentGloss': '?', 'dependent': 7}]}
 
 # Parsing result of "List books by Roald Dahl"
 def roald():
-    return {'sentences': [{'text': 'List books by Roald Dahl', 'parsetree': '(ROOT (NP (NP (NN List) (NNS books)) (PP (IN by) (NP (NNP Roald) (NNP Dahl)))))', 'indexeddependencies': [['root', 'ROOT-0', 'books-2'], ['nn', 'books-2', 'List-1'], ['nn', 'Dahl-5', 'Roald-4'], ['prep_by', 'books-2', 'Dahl-5']], 'dependencies': [['root', 'ROOT', 'books'], ['nn', 'books', 'List'], ['nn', 'Dahl', 'Roald'], ['prep_by', 'books', 'Dahl']], 'words': [['List', {'NamedEntityTag': 'O', 'PartOfSpeech': 'NN', 'CharacterOffsetEnd': '4', 'Lemma': 'list', 'CharacterOffsetBegin': '0'}], ['books', {'NamedEntityTag': 'O', 'PartOfSpeech': 'NNS', 'CharacterOffsetEnd': '10', 'Lemma': 'book', 'CharacterOffsetBegin': '5'}], ['by', {'NamedEntityTag': 'O', 'PartOfSpeech': 'IN', 'CharacterOffsetEnd': '13', 'Lemma': 'by', 'CharacterOffsetBegin': '11'}], ['Roald', {'NamedEntityTag': 'PERSON', 'PartOfSpeech': 'NNP', 'CharacterOffsetEnd': '19', 'Lemma': 'Roald', 'CharacterOffsetBegin': '14'}], ['Dahl', {'NamedEntityTag': 'PERSON', 'PartOfSpeech': 'NNP', 'CharacterOffsetEnd': '24', 'Lemma': 'Dahl', 'CharacterOffsetBegin': '20'}]]}]}
+    return {'parse': '(ROOT\n  (NP\n    (NP (NN List) (NNS books))\n    (PP (IN by)\n      (NP (NNP Roald) (NNP Dahl)))))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'books', 'dependent': 2}, {'governor': 2, 'dep': 'compound', 'governorGloss': 'books', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 5, 'dep': 'case', 'governorGloss': 'Dahl', 'dependentGloss': 'by', 'dependent': 3}, {'governor': 5, 'dep': 'compound', 'governorGloss': 'Dahl', 'dependentGloss': 'Roald', 'dependent': 4}, {'governor': 2, 'dep': 'nmod', 'governorGloss': 'books', 'dependentGloss': 'Dahl', 'dependent': 5}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'books', 'dependent': 2}, {'governor': 2, 'dep': 'compound', 'governorGloss': 'books', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 5, 'dep': 'case', 'governorGloss': 'Dahl', 'dependentGloss': 'by', 'dependent': 3}, {'governor': 5, 'dep': 'compound', 'governorGloss': 'Dahl', 'dependentGloss': 'Roald', 'dependent': 4}, {'governor': 2, 'dep': 'nmod:by', 'governorGloss': 'books', 'dependentGloss': 'Dahl', 'dependent': 5}], 'tokens': [{'originalText': 'List', 'characterOffsetEnd': 4, 'pos': 'NN', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'list', 'word': 'List', 'ner': 'O'}, {'originalText': 'books', 'characterOffsetEnd': 10, 'pos': 'NNS', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'book', 'word': 'books', 'ner': 'O'}, {'originalText': 'by', 'characterOffsetEnd': 13, 'pos': 'IN', 'characterOffsetBegin': 11, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'by', 'word': 'by', 'ner': 'O'}, {'originalText': 'Roald', 'characterOffsetEnd': 19, 'pos': 'NNP', 'characterOffsetBegin': 14, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'Roald', 'word': 'Roald', 'ner': 'PERSON'}, {'originalText': 'Dahl', 'characterOffsetEnd': 24, 'pos': 'NNP', 'characterOffsetBegin': 20, 'index': 5, 'after': '', 'before': ' ', 'lemma': 'Dahl', 'word': 'Dahl', 'ner': 'PERSON'}], 'text': 'List books by Roald Dahl', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'books', 'dependent': 2}, {'governor': 2, 'dep': 'compound', 'governorGloss': 'books', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 5, 'dep': 'case', 'governorGloss': 'Dahl', 'dependentGloss': 'by', 'dependent': 3}, {'governor': 5, 'dep': 'compound', 'governorGloss': 'Dahl', 'dependentGloss': 'Roald', 'dependent': 4}, {'governor': 2, 'dep': 'nmod:by', 'governorGloss': 'books', 'dependentGloss': 'Dahl', 'dependent': 5}]}
 
 # Parsing result of "List of presidents of France"
 def list_president2():
-    return {'sentences': [{'indexeddependencies': [['root', 'ROOT-0', 'List-1'], ['prep_of', 'List-1', 'presidents-3'], ['prep_of', 'presidents-3', 'France-5']], 'text': 'List of presidents of France', 'parsetree': '(ROOT (NP (NP (NN List)) (PP (IN of) (NP (NP (NNS presidents)) (PP (IN of) (NP (NNP France)))))))', 'dependencies': [['root', 'ROOT', 'List'], ['prep_of', 'List', 'presidents'], ['prep_of', 'presidents', 'France']], 'words': [['List', {'Lemma': 'list', 'PartOfSpeech': 'NN', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '4', 'CharacterOffsetBegin': '0'}], ['of', {'Lemma': 'of', 'PartOfSpeech': 'IN', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '7', 'CharacterOffsetBegin': '5'}], ['presidents', {'Lemma': 'president', 'PartOfSpeech': 'NNS', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '18', 'CharacterOffsetBegin': '8'}], ['of', {'Lemma': 'of', 'PartOfSpeech': 'IN', 'NamedEntityTag': 'O', 'CharacterOffsetEnd': '21', 'CharacterOffsetBegin': '19'}], ['France', {'Lemma': 'France', 'PartOfSpeech': 'NNP', 'NamedEntityTag': 'LOCATION', 'CharacterOffsetEnd': '28', 'CharacterOffsetBegin': '22'}]]}]}
+    return {'parse': '(ROOT\n  (NP\n    (NP (NN List))\n    (PP (IN of)\n      (NP\n        (NP (NNS presidents))\n        (PP (IN of)\n          (NP (NNP France)))))))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'presidents', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod', 'governorGloss': 'List', 'dependentGloss': 'presidents', 'dependent': 3}, {'governor': 5, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 4}, {'governor': 3, 'dep': 'nmod', 'governorGloss': 'presidents', 'dependentGloss': 'France', 'dependent': 5}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'presidents', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod:of', 'governorGloss': 'List', 'dependentGloss': 'presidents', 'dependent': 3}, {'governor': 5, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 4}, {'governor': 3, 'dep': 'nmod:of', 'governorGloss': 'presidents', 'dependentGloss': 'France', 'dependent': 5}], 'tokens': [{'originalText': 'List', 'characterOffsetEnd': 4, 'pos': 'NN', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'list', 'word': 'List', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 7, 'pos': 'IN', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'presidents', 'characterOffsetEnd': 18, 'pos': 'NNS', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'president', 'word': 'presidents', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 21, 'pos': 'IN', 'characterOffsetBegin': 19, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'France', 'characterOffsetEnd': 28, 'pos': 'NNP', 'characterOffsetBegin': 22, 'index': 5, 'after': '', 'before': ' ', 'lemma': 'France', 'word': 'France', 'ner': 'LOCATION'}], 'text': 'List of presidents of France', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'List', 'dependent': 1}, {'governor': 3, 'dep': 'case', 'governorGloss': 'presidents', 'dependentGloss': 'of', 'dependent': 2}, {'governor': 1, 'dep': 'nmod:of', 'governorGloss': 'List', 'dependentGloss': 'presidents', 'dependent': 3}, {'governor': 5, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 4}, {'governor': 3, 'dep': 'nmod:of', 'governorGloss': 'presidents', 'dependentGloss': 'France', 'dependent': 5}]}
 
 # Parsing result of "Give me the capital of France"
 def capital1():
-    return {'sentences': [{'parsetree': '(ROOT (S (VP (VB Give) (NP (PRP me)) (NP (NP (DT the) (NN capital)) (PP (IN of) (NP (NNP France)))))))', 'indexeddependencies': [['root', 'ROOT-0', 'Give-1'], ['iobj', 'Give-1', 'me-2'], ['det', 'capital-4', 'the-3'], ['dobj', 'Give-1', 'capital-4'], ['prep_of', 'capital-4', 'France-6']], 'text': 'Give me the capital of France', 'words': [['Give', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '0', 'CharacterOffsetEnd': '4', 'Lemma': 'give', 'PartOfSpeech': 'VB'}], ['me', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '5', 'CharacterOffsetEnd': '7', 'Lemma': 'I', 'PartOfSpeech': 'PRP'}], ['the', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '8', 'CharacterOffsetEnd': '11', 'Lemma': 'the', 'PartOfSpeech': 'DT'}], ['capital', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '12', 'CharacterOffsetEnd': '19', 'Lemma': 'capital', 'PartOfSpeech': 'NN'}], ['of', {'NamedEntityTag': 'O', 'CharacterOffsetBegin': '20', 'CharacterOffsetEnd': '22', 'Lemma': 'of', 'PartOfSpeech': 'IN'}], ['France', {'NamedEntityTag': 'LOCATION', 'CharacterOffsetBegin': '23', 'CharacterOffsetEnd': '29', 'Lemma': 'France', 'PartOfSpeech': 'NNP'}]], 'dependencies': [['root', 'ROOT', 'Give'], ['iobj', 'Give', 'me'], ['det', 'capital', 'the'], ['dobj', 'Give', 'capital'], ['prep_of', 'capital', 'France']]}]}
+    return {'parse': '(ROOT\n  (S\n    (VP (VB Give)\n      (NP (PRP me))\n      (NP\n        (NP (DT the) (NN capital))\n        (PP (IN of)\n          (NP (NNP France)))))))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Give', 'dependent': 1}, {'governor': 1, 'dep': 'iobj', 'governorGloss': 'Give', 'dependentGloss': 'me', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'capital', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 1, 'dep': 'dobj', 'governorGloss': 'Give', 'dependentGloss': 'capital', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod', 'governorGloss': 'capital', 'dependentGloss': 'France', 'dependent': 6}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Give', 'dependent': 1}, {'governor': 1, 'dep': 'iobj', 'governorGloss': 'Give', 'dependentGloss': 'me', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'capital', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 1, 'dep': 'dobj', 'governorGloss': 'Give', 'dependentGloss': 'capital', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'capital', 'dependentGloss': 'France', 'dependent': 6}], 'tokens': [{'originalText': 'Give', 'characterOffsetEnd': 4, 'pos': 'VB', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'give', 'word': 'Give', 'ner': 'O'}, {'originalText': 'me', 'characterOffsetEnd': 7, 'pos': 'PRP', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'I', 'word': 'me', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 11, 'pos': 'DT', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'capital', 'characterOffsetEnd': 19, 'pos': 'NN', 'characterOffsetBegin': 12, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'capital', 'word': 'capital', 'ner': 'O'}, {'originalText': 'of', 'characterOffsetEnd': 22, 'pos': 'IN', 'characterOffsetBegin': 20, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'of', 'word': 'of', 'ner': 'O'}, {'originalText': 'France', 'characterOffsetEnd': 29, 'pos': 'NNP', 'characterOffsetBegin': 23, 'index': 6, 'after': '', 'before': ' ', 'lemma': 'France', 'word': 'France', 'ner': 'LOCATION'}], 'text': 'Give me the capital of France', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'Give', 'dependent': 1}, {'governor': 1, 'dep': 'iobj', 'governorGloss': 'Give', 'dependentGloss': 'me', 'dependent': 2}, {'governor': 4, 'dep': 'det', 'governorGloss': 'capital', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 1, 'dep': 'dobj', 'governorGloss': 'Give', 'dependentGloss': 'capital', 'dependent': 4}, {'governor': 6, 'dep': 'case', 'governorGloss': 'France', 'dependentGloss': 'of', 'dependent': 5}, {'governor': 4, 'dep': 'nmod:of', 'governorGloss': 'capital', 'dependentGloss': 'France', 'dependent': 6}]}
 
 # Parsing result of "Give the capital of France"
 def capital2():
-    return {'sentences': [{'parsetree': '(ROOT (S (VP (VB Give) (NP (NP (DT the) (NN capital)) (PP (IN of) (NP (NNP France)))))))', 'words': [['Give', {'NamedEntityTag': 'O', 'Lemma': 'give', 'CharacterOffsetEnd': '4', 'CharacterOffsetBegin': '0', 'PartOfSpeech': 'VB'}], ['the', {'NamedEntityTag': 'O', 'Lemma': 'the', 'CharacterOffsetEnd': '8', 'CharacterOffsetBegin': '5', 'PartOfSpeech': 'DT'}], ['capital', {'NamedEntityTag': 'O', 'Lemma': 'capital', 'CharacterOffsetEnd': '16', 'CharacterOffsetBegin': '9', 'PartOfSpeech': 'NN'}], ['of', {'NamedEntityTag': 'O', 'Lemma': 'of', 'CharacterOffsetEnd': '19', 'CharacterOffsetBegin': '17', 'PartOfSpeech': 'IN'}], ['France', {'NamedEntityTag': 'LOCATION', 'Lemma': 'France', 'CharacterOffsetEnd': '26', 'CharacterOffsetBegin': '20', 'PartOfSpeech': 'NNP'}]], 'text': 'Give the capital of France', 'dependencies': [['root', 'ROOT', 'Give'], ['det', 'capital', 'the'], ['dobj', 'Give', 'capital'], ['prep_of', 'capital', 'France']], 'indexeddependencies': [['root', 'ROOT-0', 'Give-1'], ['det', 'capital-3', 'the-2'], ['dobj', 'Give-1', 'capital-3'], ['prep_of', 'capital-3', 'France-5']]}]}
+    return {'parse': '(ROOT\n  (S\n    (VP (VB Give)\n      (NP\n        (NP (DT the) (NN capital))\n        (PP (IN of)\n          (NP (NNP France)))))))', 'basic-dependencies': [{'governor': 0, 'dependentGloss': 'Give', 'governorGloss': 'ROOT', 'dep': 'ROOT', 'dependent': 1}, {'governor': 3, 'dependentGloss': 'the', 'governorGloss': 'capital', 'dep': 'det', 'dependent': 2}, {'governor': 1, 'dependentGloss': 'capital', 'governorGloss': 'Give', 'dep': 'dobj', 'dependent': 3}, {'governor': 5, 'dependentGloss': 'of', 'governorGloss': 'France', 'dep': 'case', 'dependent': 4}, {'governor': 3, 'dependentGloss': 'France', 'governorGloss': 'capital', 'dep': 'nmod', 'dependent': 5}], 'collapsed-dependencies': [{'governor': 0, 'dependentGloss': 'Give', 'governorGloss': 'ROOT', 'dep': 'ROOT', 'dependent': 1}, {'governor': 3, 'dependentGloss': 'the', 'governorGloss': 'capital', 'dep': 'det', 'dependent': 2}, {'governor': 1, 'dependentGloss': 'capital', 'governorGloss': 'Give', 'dep': 'dobj', 'dependent': 3}, {'governor': 5, 'dependentGloss': 'of', 'governorGloss': 'France', 'dep': 'case', 'dependent': 4}, {'governor': 3, 'dependentGloss': 'France', 'governorGloss': 'capital', 'dep': 'nmod:of', 'dependent': 5}], 'index': 0, 'text': 'Give the capital of France', 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dependentGloss': 'Give', 'governorGloss': 'ROOT', 'dep': 'ROOT', 'dependent': 1}, {'governor': 3, 'dependentGloss': 'the', 'governorGloss': 'capital', 'dep': 'det', 'dependent': 2}, {'governor': 1, 'dependentGloss': 'capital', 'governorGloss': 'Give', 'dep': 'dobj', 'dependent': 3}, {'governor': 5, 'dependentGloss': 'of', 'governorGloss': 'France', 'dep': 'case', 'dependent': 4}, {'governor': 3, 'dependentGloss': 'France', 'governorGloss': 'capital', 'dep': 'nmod:of', 'dependent': 5}], 'tokens': [{'originalText': 'Give', 'ner': 'O', 'lemma': 'give', 'characterOffsetBegin': 0, 'characterOffsetEnd': 4, 'index': 1, 'word': 'Give', 'pos': 'VB', 'after': ' ', 'before': ''}, {'originalText': 'the', 'ner': 'O', 'lemma': 'the', 'characterOffsetBegin': 5, 'characterOffsetEnd': 8, 'index': 2, 'word': 'the', 'pos': 'DT', 'after': ' ', 'before': ' '}, {'originalText': 'capital', 'ner': 'O', 'lemma': 'capital', 'characterOffsetBegin': 9, 'characterOffsetEnd': 16, 'index': 3, 'word': 'capital', 'pos': 'NN', 'after': ' ', 'before': ' '}, {'originalText': 'of', 'ner': 'O', 'lemma': 'of', 'characterOffsetBegin': 17, 'characterOffsetEnd': 19, 'index': 4, 'word': 'of', 'pos': 'IN', 'after': ' ', 'before': ' '}, {'originalText': 'France', 'ner': 'LOCATION', 'lemma': 'France', 'characterOffsetBegin': 20, 'characterOffsetEnd': 26, 'index': 5, 'word': 'France', 'pos': 'NNP', 'after': '', 'before': ' '}]}
 
 # Parsing result of "What is the most expensive car in the world?"
 def car():
-    return {'sentences': [{'parsetree': '(ROOT (SBARQ (WHNP (WP What)) (SQ (VBZ is) (NP (NP (DT the) (ADJP (RBS most) (JJ expensive)) (NN car)) (PP (IN in) (NP (DT the) (NN world))))) (. ?)))', 'dependencies': [['root', 'ROOT', 'is'], ['dep', 'is', 'What'], ['det', 'car', 'the'], ['advmod', 'expensive', 'most'], ['amod', 'car', 'expensive'], ['nsubj', 'is', 'car'], ['det', 'world', 'the'], ['prep_in', 'car', 'world']], 'text': 'What is the most expensive car in the world?', 'indexeddependencies': [['root', 'ROOT-0', 'is-2'], ['dep', 'is-2', 'What-1'], ['det', 'car-6', 'the-3'], ['advmod', 'expensive-5', 'most-4'], ['amod', 'car-6', 'expensive-5'], ['nsubj', 'is-2', 'car-6'], ['det', 'world-9', 'the-8'], ['prep_in', 'car-6', 'world-9']], 'words': [['What', {'CharacterOffsetEnd': '4', 'CharacterOffsetBegin': '0', 'NamedEntityTag': 'O', 'Lemma': 'what', 'PartOfSpeech': 'WP'}], ['is', {'CharacterOffsetEnd': '7', 'CharacterOffsetBegin': '5', 'NamedEntityTag': 'O', 'Lemma': 'be', 'PartOfSpeech': 'VBZ'}], ['the', {'CharacterOffsetEnd': '11', 'CharacterOffsetBegin': '8', 'NamedEntityTag': 'O', 'Lemma': 'the', 'PartOfSpeech': 'DT'}], ['most', {'CharacterOffsetEnd': '16', 'CharacterOffsetBegin': '12', 'NamedEntityTag': 'O', 'Lemma': 'most', 'PartOfSpeech': 'RBS'}], ['expensive', {'CharacterOffsetEnd': '26', 'CharacterOffsetBegin': '17', 'NamedEntityTag': 'O', 'Lemma': 'expensive', 'PartOfSpeech': 'JJ'}], ['car', {'CharacterOffsetEnd': '30', 'CharacterOffsetBegin': '27', 'NamedEntityTag': 'O', 'Lemma': 'car', 'PartOfSpeech': 'NN'}], ['in', {'CharacterOffsetEnd': '33', 'CharacterOffsetBegin': '31', 'NamedEntityTag': 'O', 'Lemma': 'in', 'PartOfSpeech': 'IN'}], ['the', {'CharacterOffsetEnd': '37', 'CharacterOffsetBegin': '34', 'NamedEntityTag': 'O', 'Lemma': 'the', 'PartOfSpeech': 'DT'}], ['world', {'CharacterOffsetEnd': '43', 'CharacterOffsetBegin': '38', 'NamedEntityTag': 'O', 'Lemma': 'world', 'PartOfSpeech': 'NN'}], ['?', {'CharacterOffsetEnd': '44', 'CharacterOffsetBegin': '43', 'NamedEntityTag': 'O', 'Lemma': '?', 'PartOfSpeech': '.'}]]}]}
+    return {'parse': '(ROOT\n  (SBARQ\n    (WHNP (WP What))\n    (SQ (VBZ is)\n      (NP\n        (NP (DT the)\n          (ADJP (RBS most) (JJ expensive))\n          (NN car))\n        (PP (IN in)\n          (NP (DT the) (NN world)))))\n    (. ?)))', 'basic-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'car', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'advmod', 'governorGloss': 'expensive', 'dependentGloss': 'most', 'dependent': 4}, {'governor': 6, 'dep': 'amod', 'governorGloss': 'car', 'dependentGloss': 'expensive', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'car', 'dependent': 6}, {'governor': 9, 'dep': 'case', 'governorGloss': 'world', 'dependentGloss': 'in', 'dependent': 7}, {'governor': 9, 'dep': 'det', 'governorGloss': 'world', 'dependentGloss': 'the', 'dependent': 8}, {'governor': 6, 'dep': 'nmod', 'governorGloss': 'car', 'dependentGloss': 'world', 'dependent': 9}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 10}], 'collapsed-ccprocessed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'car', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'advmod', 'governorGloss': 'expensive', 'dependentGloss': 'most', 'dependent': 4}, {'governor': 6, 'dep': 'amod', 'governorGloss': 'car', 'dependentGloss': 'expensive', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'car', 'dependent': 6}, {'governor': 9, 'dep': 'case', 'governorGloss': 'world', 'dependentGloss': 'in', 'dependent': 7}, {'governor': 9, 'dep': 'det', 'governorGloss': 'world', 'dependentGloss': 'the', 'dependent': 8}, {'governor': 6, 'dep': 'nmod:in', 'governorGloss': 'car', 'dependentGloss': 'world', 'dependent': 9}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 10}], 'tokens': [{'originalText': 'What', 'characterOffsetEnd': 4, 'pos': 'WP', 'characterOffsetBegin': 0, 'index': 1, 'after': ' ', 'before': '', 'lemma': 'what', 'word': 'What', 'ner': 'O'}, {'originalText': 'is', 'characterOffsetEnd': 7, 'pos': 'VBZ', 'characterOffsetBegin': 5, 'index': 2, 'after': ' ', 'before': ' ', 'lemma': 'be', 'word': 'is', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 11, 'pos': 'DT', 'characterOffsetBegin': 8, 'index': 3, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'most', 'characterOffsetEnd': 16, 'pos': 'RBS', 'characterOffsetBegin': 12, 'index': 4, 'after': ' ', 'before': ' ', 'lemma': 'most', 'word': 'most', 'ner': 'O'}, {'originalText': 'expensive', 'characterOffsetEnd': 26, 'pos': 'JJ', 'characterOffsetBegin': 17, 'index': 5, 'after': ' ', 'before': ' ', 'lemma': 'expensive', 'word': 'expensive', 'ner': 'O'}, {'originalText': 'car', 'characterOffsetEnd': 30, 'pos': 'NN', 'characterOffsetBegin': 27, 'index': 6, 'after': ' ', 'before': ' ', 'lemma': 'car', 'word': 'car', 'ner': 'O'}, {'originalText': 'in', 'characterOffsetEnd': 33, 'pos': 'IN', 'characterOffsetBegin': 31, 'index': 7, 'after': ' ', 'before': ' ', 'lemma': 'in', 'word': 'in', 'ner': 'O'}, {'originalText': 'the', 'characterOffsetEnd': 37, 'pos': 'DT', 'characterOffsetBegin': 34, 'index': 8, 'after': ' ', 'before': ' ', 'lemma': 'the', 'word': 'the', 'ner': 'O'}, {'originalText': 'world', 'characterOffsetEnd': 43, 'pos': 'NN', 'characterOffsetBegin': 38, 'index': 9, 'after': '', 'before': ' ', 'lemma': 'world', 'word': 'world', 'ner': 'O'}, {'originalText': '?', 'characterOffsetEnd': 44, 'pos': '.', 'characterOffsetBegin': 43, 'index': 10, 'after': '', 'before': '', 'lemma': '?', 'word': '?', 'ner': 'O'}], 'text': 'What is the most expensive car in the world?', 'index': 0, 'collapsed-dependencies': [{'governor': 0, 'dep': 'ROOT', 'governorGloss': 'ROOT', 'dependentGloss': 'is', 'dependent': 2}, {'governor': 2, 'dep': 'dobj', 'governorGloss': 'is', 'dependentGloss': 'What', 'dependent': 1}, {'governor': 6, 'dep': 'det', 'governorGloss': 'car', 'dependentGloss': 'the', 'dependent': 3}, {'governor': 5, 'dep': 'advmod', 'governorGloss': 'expensive', 'dependentGloss': 'most', 'dependent': 4}, {'governor': 6, 'dep': 'amod', 'governorGloss': 'car', 'dependentGloss': 'expensive', 'dependent': 5}, {'governor': 2, 'dep': 'nsubj', 'governorGloss': 'is', 'dependentGloss': 'car', 'dependent': 6}, {'governor': 9, 'dep': 'case', 'governorGloss': 'world', 'dependentGloss': 'in', 'dependent': 7}, {'governor': 9, 'dep': 'det', 'governorGloss': 'world', 'dependentGloss': 'the', 'dependent': 8}, {'governor': 6, 'dep': 'nmod:in', 'governorGloss': 'car', 'dependentGloss': 'world', 'dependent': 9}, {'governor': 2, 'dep': 'punct', 'governorGloss': 'is', 'dependentGloss': '?', 'dependent': 10}]}
 
 def tripleProductionData():
     '''

--- a/tests/data_deep.py
+++ b/tests/data_deep.py
@@ -236,7 +236,7 @@ expected = {
     T(R('chocolate sunday'), R('definition'), M()),
 
     'What is the D Day?':
-    T(R('D Day'), R('definition'), M()),
+    T(R('d day'), R('definition'), M()),
 
     'When was D-Day?':
     T(R('D-Day'), R('date'), M()),

--- a/tests/test_deep.py
+++ b/tests/test_deep.py
@@ -42,6 +42,14 @@ class RequestHandlerTest(PPPTestCase(app), InclusionTestCase):
         self.getAnswer("Yoda", 0)
 
     def testQuestions(self):
+        nbFailure = 0
         for (sentence, expectedTree) in data_deep.expected.items():
-            self.checkQuestion(sentence, expectedTree)
-        print("Deep test: %s questions successfully checked." % len(data_deep.expected.items()), file=sys.stderr)
+            try:
+                self.checkQuestion(sentence, expectedTree)
+            except AssertionError:
+                print("[Deep test] The following question check failed: %s" % sentence, file=sys.stderr)
+                nbFailure += 1
+        print("[Deep test] %s question checks succeeded." % (len(data_deep.expected.items())-nbFailure), file=sys.stderr)
+        if nbFailure > 0:
+            print("[Deep test] %s question checks failed." % nbFailure, file=sys.stderr)
+            raise AssertionError

--- a/tests/test_dependencyAnalysis.py
+++ b/tests/test_dependencyAnalysis.py
@@ -8,19 +8,19 @@ from unittest import TestCase
 class HierarchyTests(TestCase):
 
     def testQuestion(self):
-        tree=computeTree(data.give_president_of_USA()['sentences'][0])
+        tree=computeTree(data.give_president_of_USA())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         self.assertEqual(simplify(tree), 'who')
 
     def testQuestion2(self):
-        tree=computeTree(data.give_how_old()['sentences'][0])
+        tree=computeTree(data.give_how_old())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         self.assertEqual(simplify(tree), 'how old')
 
     def testHierarchySimplification(self):
-        tree=computeTree(data.give_president_of_USA()['sentences'][0])
+        tree=computeTree(data.give_president_of_USA())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -63,7 +63,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(us.dfsTag, 0)
 
     def testIgnore(self):
-        tree=computeTree(data.give_how_old()['sentences'][0])
+        tree=computeTree(data.give_how_old())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -88,7 +88,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(are.dfsTag, 0)
 
     def testHierarchySimplification2(self):
-        tree=computeTree(data.give_USA_president()['sentences'][0])
+        tree=computeTree(data.give_USA_president())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -122,7 +122,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(us.dfsTag, 0)
 
     def testHierarchyConnectors1(self):
-        tree=computeTree(data.give_opera()['sentences'][0])
+        tree=computeTree(data.give_opera())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -192,7 +192,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(sullivan.dfsTag, 0)
 
     def testHierarchyConnectors2(self):
-        tree=computeTree(data.give_chief()['sentences'][0])
+        tree=computeTree(data.give_chief())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -253,7 +253,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(prime.dfsTag, 0)
 
     def testYesNoQuestion(self):
-        tree=computeTree(data.give_born()['sentences'][0])
+        tree=computeTree(data.give_born())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -287,7 +287,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(date.dfsTag, 0)
 
     def testNoQW(self):
-        tree=computeTree(data.birth_date()['sentences'][0])
+        tree=computeTree(data.birth_date())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -321,7 +321,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(france.dfsTag, 0)
 
     def testQuestionInfo(self):
-        tree=computeTree(data.birth_place()['sentences'][0])
+        tree=computeTree(data.birth_place())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         simplify(tree)
@@ -355,7 +355,7 @@ class HierarchyTests(TestCase):
         self.assertEqual(obama.dfsTag, 0)
 
     def testPassIdentity(self):
-        tree=computeTree(data.mickey()['sentences'][0])
+        tree=computeTree(data.mickey())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         NamedEntityMerging(tree).merge()

--- a/tests/test_dependencyTree.py
+++ b/tests/test_dependencyTree.py
@@ -65,7 +65,7 @@ class DependenciesTreeTests(TestCase):
     ###############
 
     def testStr1(self):
-        tree=computeTree(data.give_john_smith()['sentences'][0])
+        tree=computeTree(data.give_john_smith())
         self.maxDiff=None
         tree.sort()
         self.assertEqual(str(tree), data.give_john_smith_string())
@@ -102,7 +102,7 @@ class DependenciesTreeTests(TestCase):
         foo2 = DependenciesTree('foo2', 3, namedEntityTag='42')
         bar = DependenciesTree('bar', 2, namedEntityTag='undef', dependency = 'nn', parent = foo1)
         generator = TreeGenerator(None)
-        generator.nameToNodes = {'foo1-1' : foo1, 'bar-2' : bar, 'foo2-3' : foo2}
+        generator.nameToNodes = {('foo1',1) : foo1, ('bar',2) : bar, ('foo2', 3) : foo2}
         generator._correctTree(foo1)
         self.assertEqual(bar.namedEntityTag, '42')
 
@@ -111,7 +111,7 @@ class DependenciesTreeTests(TestCase):
         foo2 = DependenciesTree('foo2', 3, namedEntityTag='42')
         bar = DependenciesTree('bar', 2, namedEntityTag='27', dependency = 'nn', parent = foo1)
         generator = TreeGenerator(None)
-        generator.nameToNodes = {'foo1-1' : foo1, 'bar-2' : bar, 'foo2-3' : foo2}
+        generator.nameToNodes = {('foo1',1) : foo1, ('bar',2) : bar, ('foo2', 3) : foo2}
         generator._correctTree(foo1)
         self.assertEqual(bar.namedEntityTag, '27')
 
@@ -120,6 +120,6 @@ class DependenciesTreeTests(TestCase):
         foo2 = DependenciesTree('foo2', 3, namedEntityTag='42')
         bar = DependenciesTree('bar', 2, namedEntityTag='undef', dependency = 'amod', parent = foo1)
         generator = TreeGenerator(None)
-        generator.nameToNodes = {'foo1-1' : foo1, 'bar-2' : bar, 'foo2-3' : foo2}
+        generator.nameToNodes = {('foo1',1) : foo1, ('bar',2) : bar, ('foo2', 3) : foo2}
         generator._correctTree(foo1)
         self.assertEqual(bar.namedEntityTag, 'undef')

--- a/tests/test_initialMerge.py
+++ b/tests/test_initialMerge.py
@@ -114,7 +114,7 @@ class PreprocessingMergeTests(TestCase):
         self.assertEqual(parent.child, [child])
 
     def testNamedEntity1(self):
-        tree=computeTree(data.give_john_smith()['sentences'][0])
+        tree=computeTree(data.give_john_smith())
         NamedEntityMerging(tree).merge()
         tree.sort()
         root=tree
@@ -130,7 +130,7 @@ class PreprocessingMergeTests(TestCase):
         lives=root.child[0]
         self.assertEqual(lives.wordList, [Word("lives", 3, 'VBZ')])
         self.assertEqual(lives.namedEntityTag, 'undef')
-        self.assertEqual(lives.dependency, 'root')
+        self.assertEqual(lives.dependency, 'ROOT')
         self.assertEqual(lives.parent, tree)
         self.assertEqual(len(lives.child), 2)
         self.assertEqual(lives.subtreeType, 'undef')
@@ -164,7 +164,7 @@ class PreprocessingMergeTests(TestCase):
         self.assertEqual(the.dfsTag, 0)
 
     def testNamedEntity2(self):
-        tree=computeTree(data.give_obama_president_usa()['sentences'][0])
+        tree=computeTree(data.give_obama_president_usa())
         NamedEntityMerging(tree).merge()
         tree.sort()
         root=tree
@@ -180,7 +180,7 @@ class PreprocessingMergeTests(TestCase):
         is_=root.child[0]
         self.assertEqual(is_.wordList, [Word("is", 2, 'VBZ')])
         self.assertEqual(is_.namedEntityTag, 'undef')
-        self.assertEqual(is_.dependency, 'root')
+        self.assertEqual(is_.dependency, 'ROOT')
         self.assertEqual(is_.parent, tree)
         self.assertEqual(len(is_.child), 2)
         self.assertEqual(is_.subtreeType, 'undef')
@@ -216,14 +216,14 @@ class PreprocessingMergeTests(TestCase):
         united=president.child[1]
         self.assertEqual(united.wordList, [Word("United", 4, 'NNP'), Word("States", 5, 'NNPS')])
         self.assertEqual(united.namedEntityTag, 'LOCATION')
-        self.assertEqual(united.dependency, 'nn')
+        self.assertEqual(united.dependency, 'compound')
         self.assertEqual(united.parent, president)
         self.assertEqual(len(united.child), 0)
         self.assertEqual(united.subtreeType, 'undef')
         self.assertEqual(united.dfsTag, 0)
 
     def testStr2(self):
-        tree=computeTree(data.give_john_smith()['sentences'][0])
+        tree=computeTree(data.give_john_smith())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         self.maxDiff=None

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 class StandardTripleTests(TestCase):
 
     def testAndnormalFormProduction(self):
-        tree = computeTree(data.give_chief()['sentences'][0])
+        tree = computeTree(data.give_chief())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -59,7 +59,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testSuperlativenormalFormProduction(self):
-        tree = computeTree(data.give_opera()['sentences'][0])
+        tree = computeTree(data.give_opera())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -99,7 +99,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testnormalFormProduction1(self):
-        tree = computeTree(data.give_president_of_USA()['sentences'][0])
+        tree = computeTree(data.give_president_of_USA())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -124,7 +124,7 @@ class StandardTripleTests(TestCase):
         sentence = 'Who wrote "Lucy in the Sky with Diamonds" and "Let It Be"?'
         nonAmbiguousSentence = handler.pull(sentence)
         result=data.give_LSD_LIB()
-        tree=computeTree(result['sentences'][0])
+        tree=computeTree(result)
         handler.push(tree)
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
@@ -225,7 +225,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testnormalFormProduction3(self):
-        tree = computeTree(data.give_obama_president_usa()['sentences'][0])
+        tree = computeTree(data.give_obama_president_usa())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -291,7 +291,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testnormalFormProductionR8(self):
-        tree = computeTree(data.mistake()['sentences'][0])
+        tree = computeTree(data.mistake())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -346,7 +346,7 @@ class StandardTripleTests(TestCase):
 
 
     def testnormalFormProductionSuperl(self):
-        tree = computeTree(data.tanzania()['sentences'][0])
+        tree = computeTree(data.tanzania())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -377,7 +377,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testnormalFormProductionSuperl2(self):
-        tree = computeTree(data.car()['sentences'][0])
+        tree = computeTree(data.car())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -408,13 +408,13 @@ class StandardTripleTests(TestCase):
 })
 
     def testCop(self):
-        tree = computeTree(data.black()['sentences'][0])
+        tree = computeTree(data.black())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         self.assertRaises(GrammaticalError, lambda: simplify(tree))
 
     def testExists(self):
-        tree = computeTree(data.king_england()['sentences'][0])
+        tree = computeTree(data.king_england())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -438,7 +438,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testSemiQuestionWord1(self):
-        tree = computeTree(data.roald()['sentences'][0])
+        tree = computeTree(data.roald())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -459,7 +459,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testSemiQuestionWord3(self):
-        tree = computeTree(data.list_president2()['sentences'][0])
+        tree = computeTree(data.list_president2())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -480,7 +480,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testSemiQuestionWord4(self):
-        tree = computeTree(data.capital1()['sentences'][0])
+        tree = computeTree(data.capital1())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)
@@ -501,7 +501,7 @@ class StandardTripleTests(TestCase):
 })
 
     def testSemiQuestionWord5(self):
-        tree = computeTree(data.capital2()['sentences'][0])
+        tree = computeTree(data.capital2())
         NamedEntityMerging(tree).merge()
         PrepositionMerging(tree).merge()
         qw = simplify(tree)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -46,7 +46,7 @@ class PreprocessingMergeTests(TestCase):
         sentence = 'Who wrote "Lucy in the Sky with Diamonds" and "Let It Be"?'
         nonAmbiguousSentence = handler.pull(sentence)
         result=data.give_LSD_LIB()
-        tree=computeTree(result['sentences'][0])
+        tree=computeTree(result)
         handler.push(tree)
         tree.sort()
         root=tree
@@ -62,7 +62,7 @@ class PreprocessingMergeTests(TestCase):
         wrote=root.child[0]
         self.assertEqual(wrote.wordList, [Word("wrote", 2, 'VBD')])
         self.assertEqual(wrote.namedEntityTag, 'undef')
-        self.assertEqual(wrote.dependency, 'root')
+        self.assertEqual(wrote.dependency, 'ROOT')
         self.assertEqual(wrote.parent, root)
         self.assertEqual(len(wrote.child), 2)
         self.assertEqual(wrote.subtreeType, 'undef')


### PR DESCRIPTION
**Dependency: https://github.com/ProjetPP/Scripts/pull/7**

These are the required changes to use the [CoreNLP server](http://stanfordnlp.github.io/CoreNLP/corenlp-server.html).

I already explained a bit in #148 what were the main issues. CoreNLP does not use the same dependencies as before, so I needed to adapt some code.
For the moment, I transform these new dependencies into the older ones (see [processForCompatibility](https://github.com/ProjetPP/PPP-QuestionParsing-Grammatical/blob/http_corenlp/ppp_questionparsing_grammatical/dependencyTree.py#L318)). The idea is to adapt our algorithms to these new dependencies in the future.

I realized that our "unit tests" are not unit at all, since a lot of them rely on the output of CoreNLP. This is why I had to rewrite nearly entirely the file [data.py](https://github.com/ProjetPP/PPP-QuestionParsing-Grammatical/blob/http_corenlp/tests/data.py). A great idea would be to write better tests...
